### PR TITLE
Revert "Remove `isLineTerminator` and `isWord` flag from `IChar`"

### DIFF
--- a/modules/recheck/shared/src/main/scala/codes/quine/labo/recheck/automaton/EpsNFA.scala
+++ b/modules/recheck/shared/src/main/scala/codes/quine/labo/recheck/automaton/EpsNFA.scala
@@ -58,8 +58,7 @@ final case class EpsNFA[Q](alphabet: ICharSet, stateSet: Set[Q], init: Q, accept
     ctx.interrupt {
       // Obtains a set of possible character information.
       // `CharInfo(true, false)` means a beginning or ending marker.
-      val icharToCharInfo = alphabet.chars.iterator.map(ch => ch -> CharInfo(ch.isLineTerminator, ch.isWord)).toMap
-      val charInfoSet = icharToCharInfo.values.toSet ++ Set(CharInfo(true, false))
+      val charInfoSet = alphabet.chars.toSet.map(CharInfo.from) ++ Set(CharInfo(true, false))
 
       /** Skips ε-transitions from the state and collects not ε-transition or terminal state. */
       def buildClosure(c0: CharInfo, cs: Set[CharInfo], q: Q, loops: Set[Int]): Seq[(Q, Option[Consume[Q]])] =
@@ -76,7 +75,7 @@ final case class EpsNFA[Q](alphabet: ICharSet, stateSet: Set[Q], init: Q, accept
                 if (loops.contains(loop)) Vector.empty // An ε-loop is detected.
                 else buildClosure(c0, cs, q1, loops)
               case Some(Consume(chs, q1, pos)) =>
-                val newChs = chs.filter(ch => cs.contains(icharToCharInfo(ch)))
+                val newChs = chs.filter(ch => cs.contains(CharInfo.from(ch)))
                 if (newChs.nonEmpty) Vector((q, Some(Consume(newChs, q1, pos))))
                 else Vector.empty
               case None =>
@@ -112,7 +111,7 @@ final case class EpsNFA[Q](alphabet: ICharSet, stateSet: Set[Q], init: Q, accept
           p match {
             case Some(Consume(chs, q1, loc)) =>
               for (ch <- chs) {
-                val c1 = icharToCharInfo(ch)
+                val c1 = CharInfo.from(ch)
                 val qps1 = closure(c1, q1)
                 val qs1 = qps1.map(_._1)
                 d(ch) = d(ch) :+ (c1, qs1)
@@ -214,4 +213,11 @@ object EpsNFA {
     * because there is no character which is a line terminator and also a word.
     */
   final case class CharInfo(isLineTerminator: Boolean, isWord: Boolean)
+
+  /** CharInfo utilities. */
+  object CharInfo {
+
+    /** Extracts a character information from the interval set. */
+    def from(ch: IChar): CharInfo = CharInfo(ch.isLineTerminator, ch.isWord)
+  }
 }

--- a/modules/recheck/shared/src/main/scala/codes/quine/labo/recheck/automaton/EpsNFACompiler.scala
+++ b/modules/recheck/shared/src/main/scala/codes/quine/labo/recheck/automaton/EpsNFACompiler.scala
@@ -24,7 +24,7 @@ object EpsNFACompiler {
       (stateSet, init, accept, tau) <- {
         val FlagSet(_, ignoreCase, _, dotAll, unicode, sticky) = pattern.flagSet
 
-        // Mutable states:
+        // Mutable states.
         var counterQ = 0 // A next state counter.
         def nextQ(): Int = {
           val q = counterQ
@@ -154,7 +154,7 @@ object EpsNFACompiler {
             val dot = IChar.dot(ignoreCase, dotAll, unicode)
             val i = nextQ()
             val a = nextQ()
-            tau.addOne(i -> Consume(alphabet.refine(dot), a, node.loc))
+            tau.addOne(i -> Consume(alphabet.refine(dot).toSet, a, node.loc))
             Success((i, a))
           case BackReference(_)      => Failure(new UnsupportedException("back-reference"))
           case NamedBackReference(_) => Failure(new UnsupportedException("named back-reference"))

--- a/modules/recheck/shared/src/main/scala/codes/quine/labo/recheck/data/IChar.scala
+++ b/modules/recheck/shared/src/main/scala/codes/quine/labo/recheck/data/IChar.scala
@@ -6,8 +6,18 @@ import codes.quine.labo.recheck.data.unicode.IntervalSet
 import codes.quine.labo.recheck.data.unicode.IntervalSet._
 import codes.quine.labo.recheck.data.unicode.Property
 
-/** IChar is a wrapper of code point interval set with extra information. */
-final case class IChar(set: IntervalSet[UChar]) extends Ordered[IChar] {
+/** IChar is a code point interval set with extra information. */
+final case class IChar(
+    set: IntervalSet[UChar],
+    isLineTerminator: Boolean = false,
+    isWord: Boolean = false
+) extends Ordered[IChar] {
+
+  /** Marks this set contains line terminator characters. */
+  def withLineTerminator: IChar = copy(isLineTerminator = true)
+
+  /** Marks this set contains word characters. */
+  def withWord: IChar = copy(isWord = true)
 
   /** Checks whether this interval set is empty or not. */
   def isEmpty: Boolean = set.isEmpty
@@ -15,28 +25,23 @@ final case class IChar(set: IntervalSet[UChar]) extends Ordered[IChar] {
   /** Negates [[isEmpty]]. */
   def nonEmpty: Boolean = set.nonEmpty
 
-  /** Checks whether this interval set is included in new-line characters. */
-  def isLineTerminator: Boolean = set.isSubsetOf(IChar.LineTerminator.set)
-
-  /** Checks whether this interval set is included in word characters. */
-  def isWord: Boolean = set.isSubsetOf(IChar.Word.set)
-
   /** Computes a complement of this interval set. */
   def complement(unicode: Boolean): IChar = {
     val (xys, z) = set.intervals.foldLeft((IndexedSeq.empty[(UChar, UChar)], UChar(0))) { case ((seq, x), (y, z)) =>
       (seq :+ (x, y), z)
     }
-    IChar(IntervalSet.from(xys :+ (z, UChar(if (unicode) 0x110000 else 0x10000))))
+    IChar(IntervalSet.from(xys :+ (z, UChar(if (unicode) 0x110000 else 0x10000))), isLineTerminator, isWord)
   }
 
   /** Computes a union of two interval sets. */
   def union(that: IChar): IChar =
-    IChar(set.union(that.set))
+    IChar(set.union(that.set), isLineTerminator || that.isLineTerminator, isWord || that.isWord)
 
   /** Computes a partition of two interval sets. */
   def partition(that: IChar): Partition[IChar] = {
     val Partition(is, ls, rs) = set.partition(that.set)
-    Partition(IChar(is), IChar(ls), IChar(rs))
+    val ic = IChar(is, isLineTerminator || that.isLineTerminator, isWord || that.isWord)
+    Partition(ic, copy(set = ls), that.copy(set = rs))
   }
 
   /** Computes a difference interval set. */
@@ -64,7 +69,7 @@ final case class IChar(set: IntervalSet[UChar]) extends Ordered[IChar] {
       case (x, y) if x.value + 1 == y.value => showUCharInClass(x)
       case (x, y)                           => s"${showUCharInClass(x)}-${showUCharInClass(UChar(y.value - 1))}"
     }
-    cls.mkString("[", "", "]")
+    cls.mkString("[", "", "]" ++ (if (isLineTerminator) "n" else "") ++ (if (isWord) "w" else ""))
   }
 }
 
@@ -72,18 +77,19 @@ final case class IChar(set: IntervalSet[UChar]) extends Ordered[IChar] {
 object IChar {
 
   /** [[scala.math.Ordering]] instance for [[IChar]]. */
-  private val ordering: Ordering[IChar] = Ordering.by[IChar, IntervalSet[UChar]](_.set)
+  private val ordering: Ordering[IChar] =
+    Ordering.by[IChar, IntervalSet[UChar]](_.set).orElseBy(_.isLineTerminator).orElseBy(_.isWord)
 
-  /** Creates an ichar containing any code points. */
+  /** Creates an interval set containing any code points. */
   lazy val Any: IChar = IChar(IntervalSet((UChar(0), UChar(0x110000))))
 
-  /** Creates an ichar containing any UTF-16 code points. */
+  /** Creates an interval set containing any UTF-16 code points. */
   lazy val Any16: IChar = IChar(IntervalSet((UChar(0), UChar(0x10000))))
 
-  /** Returns an ichar containing digit characters. */
+  /** Returns an interval set containing digit characters. */
   lazy val Digit: IChar = IChar(IntervalSet((UChar('0'), UChar('9' + 1))))
 
-  /** Returns an ichar containing white-space characters. */
+  /** Returns an interval set containing white-space characters. */
   lazy val Space: IChar = IChar(
     IntervalSet(
       (UChar('\t'), UChar('\t' + 1)), // <TAB>
@@ -114,11 +120,11 @@ object IChar {
     )
   )
 
-  /** Returns an interval set containing code points have the unicode property . */
+  /** Return an interval set containing the unicode property code points. */
   def UnicodeProperty(name: String): Option[IChar] =
     Property.generalCategory(name).orElse(Property.binary(name)).map(IChar(_))
 
-  /** Returns an interval set containing code points have the unicode property with the value. */
+  /** Return an interval set containing the unicode property code points. */
   def UnicodePropertyValue(name: String, value: String): Option[IChar] = {
     val optSet = Property.NonBinaryPropertyAliases.getOrElse(name, name) match {
       case "General_Category"  => Property.generalCategory(value)
@@ -155,8 +161,9 @@ object IChar {
   /** Normalizes the code point interval set. */
   def canonicalize(c: IChar, unicode: Boolean): IChar = {
     val conversions = if (unicode) CaseMap.Fold else CaseMap.Upper
-    IChar(conversions.foldLeft(c.set) { case (set, Conversion(dom, offset)) =>
+    val set = conversions.foldLeft(c.set) { case (set, Conversion(dom, offset)) =>
       set.mapIntersection(dom)(u => UChar(u.value + offset))
-    })
+    }
+    c.copy(set = set)
   }
 }

--- a/modules/recheck/shared/src/main/scala/codes/quine/labo/recheck/data/ICharSet.scala
+++ b/modules/recheck/shared/src/main/scala/codes/quine/labo/recheck/data/ICharSet.scala
@@ -28,10 +28,10 @@ final case class ICharSet(chars: Seq[IChar]) {
   def any: Set[IChar] = chars.toSet
 
   /** A character set for a 'dot' pattern. */
-  def dot: Set[IChar] = any.diff(lineTerminator)
+  def dot: Set[IChar] = any.diff(newline)
 
-  /** A character set for new-line characters. */
-  def lineTerminator: Set[IChar] = refine(IChar.LineTerminator)
+  /** A character set for newline characters. */
+  def newline: Set[IChar] = refine(IChar.LineTerminator)
 }
 
 /** ICharSet utilities. */

--- a/modules/recheck/shared/src/main/scala/codes/quine/labo/recheck/regexp/Pattern.scala
+++ b/modules/recheck/shared/src/main/scala/codes/quine/labo/recheck/regexp/Pattern.scala
@@ -97,8 +97,8 @@ final case class Pattern(node: Node, flagSet: FlagSet) {
       val FlagSet(_, ignoreCase, _, dotAll, unicode, _) = flagSet
       val set = ICharSet
         .any(ignoreCase, unicode)
-        .pipe(set => if (needsLineTerminatorDistinction) set.add(IChar.LineTerminator) else set)
-        .pipe(set => if (needsWordDistinction) set.add(IChar.Word) else set)
+        .pipe(set => if (needsLineTerminatorDistinction) set.add(IChar.LineTerminator.withLineTerminator) else set)
+        .pipe(set => if (needsWordDistinction) set.add(IChar.Word.withWord) else set)
 
       def loop(node: Node): Try[Seq[IChar]] = ctx.interrupt(node match {
         case Disjunction(ns)       => TryUtil.traverse(ns)(loop).map(_.flatten)
@@ -327,7 +327,7 @@ object Pattern {
     def isEmpty: Boolean = child.isEmpty
   }
 
-  /** Star is a zero-or-more repetition pattern. (e.g. `/x*&#47;` or `/x*?/`) */
+  /** Star is a zero-or-more repetition pattern. (e.g. `/x*&#47; or `/x*?/`) */
   final case class Star(nonGreedy: Boolean, child: Node) extends Node {
     def captureRange: CaptureRange = child.captureRange
     def isEmpty: Boolean = true
@@ -439,7 +439,7 @@ object Pattern {
 
     def toIChar(unicode: Boolean): Try[IChar] =
       // Inversion will be done in automaton translation instead of here.
-      TryUtil.traverse(children)(_.toIChar(unicode)).map(IChar.union)
+      TryUtil.traverse(children)(_.toIChar(unicode)).map(IChar.union(_))
   }
 
   /** ClassRange is a character range pattern in a class. */

--- a/modules/recheck/shared/src/test/scala/codes/quine/labo/recheck/automaton/AutomatonCheckerSuite.scala
+++ b/modules/recheck/shared/src/test/scala/codes/quine/labo/recheck/automaton/AutomatonCheckerSuite.scala
@@ -46,11 +46,7 @@ class AutomatonCheckerSuite extends munit.FunSuite {
     assertEquals(
       check("^.*a.*a$", "s"),
       Success(
-        Polynomial(
-          2,
-          Witness(Seq((Seq(other), Seq(a, other))), Seq(other)),
-          Hotspot(Seq(Spot(1, 2, Heat), Spot(3, 5, Heat)))
-        )
+        Polynomial(2, Witness(Seq((Seq(a), Seq(a))), Seq(other)), Hotspot(Seq(Spot(1, 2, Heat), Spot(3, 5, Heat))))
       )
     )
     assertEquals(
@@ -58,7 +54,7 @@ class AutomatonCheckerSuite extends munit.FunSuite {
       Success(
         Polynomial(
           2,
-          Witness(Seq((Seq(a), Seq(a, a))), Seq(a, a)),
+          Witness(Seq((Seq(a, a), Seq(a, a))), Seq(a, other, a, a, a)),
           Hotspot(Seq(Spot(2, 4, Heat), Spot(6, 7, Heat), Spot(8, 10, Heat)))
         )
       )
@@ -68,7 +64,7 @@ class AutomatonCheckerSuite extends munit.FunSuite {
       Success(
         Polynomial(
           3,
-          Witness(Seq((Seq(other), Seq(a, other)), (Seq(a), Seq(a))), Seq(other)),
+          Witness(Seq((Seq(other), Seq(a)), (Seq.empty, Seq(a))), Seq(other)),
           Hotspot(Seq(Spot(1, 2, Heat), Spot(3, 5, Heat), Spot(6, 8, Heat)))
         )
       )
@@ -94,7 +90,7 @@ class AutomatonCheckerSuite extends munit.FunSuite {
       check("^(a|b|ab)*$", ""),
       Success(
         Exponential(
-          Witness(Seq((Seq(b), Seq(a, b))), Seq(other2)),
+          Witness(Seq((Seq(a), Seq(a, b))), Seq(other2)),
           Hotspot(Seq(Spot(2, 3, Heat), Spot(4, 5, Heat), Spot(6, 8, Heat)))
         )
       )
@@ -103,7 +99,7 @@ class AutomatonCheckerSuite extends munit.FunSuite {
       check("^(aa|b|aab)*$", ""),
       Success(
         Exponential(
-          Witness(Seq((Seq(a), Seq(a, a, a, b, a))), Seq(other2)),
+          Witness(Seq((Seq(a, a), Seq(b, a, a, b, a, a))), Seq(other2)),
           Hotspot(Seq(Spot(2, 4, Heat), Spot(5, 6, Heat), Spot(7, 10, Heat)))
         )
       )

--- a/modules/recheck/shared/src/test/scala/codes/quine/labo/recheck/automaton/EpsNFACompilerSuite.scala
+++ b/modules/recheck/shared/src/test/scala/codes/quine/labo/recheck/automaton/EpsNFACompilerSuite.scala
@@ -103,7 +103,7 @@ class EpsNFACompilerSuite extends munit.FunSuite {
         EpsNFACompiler.compile(Pattern(Sequence(Seq(LineBegin(), WordBoundary(false), LineEnd())), flagSet0)),
         Success(
           EpsNFA(
-            ICharSet.any(false, false).add(IChar.Word),
+            ICharSet.any(false, false).add(IChar.Word.withWord),
             Set(0, 1, 2, 3, 4, 5),
             0,
             5,
@@ -121,7 +121,7 @@ class EpsNFACompilerSuite extends munit.FunSuite {
         EpsNFACompiler.compile(Pattern(Sequence(Seq(LineBegin(), WordBoundary(true), LineEnd())), flagSet0)),
         Success(
           EpsNFA(
-            ICharSet.any(false, false).add(IChar.Word),
+            ICharSet.any(false, false).add(IChar.Word.withWord),
             Set(0, 1, 2, 3, 4, 5),
             0,
             5,

--- a/modules/recheck/shared/src/test/scala/codes/quine/labo/recheck/automaton/EpsNFASuite.scala
+++ b/modules/recheck/shared/src/test/scala/codes/quine/labo/recheck/automaton/EpsNFASuite.scala
@@ -47,6 +47,12 @@ class EpsNFASuite extends munit.FunSuite {
     assertEquals(AssertKind.WordBoundaryNot.toCharInfoSet(word), Set(word))
   }
 
+  test("EpsNFA.CharInfo.from") {
+    assertEquals(CharInfo.from(IChar('a')), CharInfo(false, false))
+    assertEquals(CharInfo.from(IChar('a').withLineTerminator), CharInfo(true, false))
+    assertEquals(CharInfo.from(IChar('a').withWord), CharInfo(false, true))
+  }
+
   test("EpsNFA#toGraphviz") {
     val nfa = EpsNFA(
       ICharSet.any(false, false).add(IChar('a')),
@@ -87,7 +93,7 @@ class EpsNFASuite extends munit.FunSuite {
 
   test("EpsNFA#toOrderedNFA") {
     val nfa1 = EpsNFA(
-      ICharSet.any(false, false).add(IChar('\n')),
+      ICharSet.any(false, false).add(IChar('\n').withLineTerminator),
       Set(0, 1, 2, 3, 4, 5, 6),
       0,
       6,
@@ -95,7 +101,7 @@ class EpsNFASuite extends munit.FunSuite {
         0 -> Eps(Seq(1, 5)),
         1 -> LoopEnter(0, 2),
         2 -> Eps(Seq(3, 4)),
-        3 -> Consume(Set(IChar('\n')), 0),
+        3 -> Consume(Set(IChar('\n').withLineTerminator), 0),
         4 -> Assert(AssertKind.LineEnd, 0),
         5 -> LoopExit(0, 6)
       )
@@ -103,19 +109,19 @@ class EpsNFASuite extends munit.FunSuite {
     assertEquals(
       nfa1.toOrderedNFA,
       OrderedNFA(
-        Set(IChar('\n'), IChar('\n').complement(false)),
+        Set(IChar('\n').withLineTerminator, IChar('\n').complement(false)),
         Set((CharInfo(true, false), Seq(3, 6))),
         Vector((CharInfo(true, false), Seq(3, 6))),
         Set((CharInfo(true, false), Seq(3, 6))),
         Map(
-          ((CharInfo(true, false), Seq(3, 6)), IChar('\n')) -> Vector(
+          ((CharInfo(true, false), Seq(3, 6)), IChar('\n').withLineTerminator) -> Vector(
             (CharInfo(true, false), Seq(3, 6))
           )
         )
       )
     )
     val nfa2 = EpsNFA(
-      ICharSet.any(false, false).add(IChar('\n')).add(IChar('a')),
+      ICharSet.any(false, false).add(IChar('\n').withLineTerminator).add(IChar('a').withWord),
       Set(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
       0,
       10,
@@ -124,8 +130,8 @@ class EpsNFASuite extends munit.FunSuite {
         1 -> Eps(Seq(2, 8)),
         2 -> LoopEnter(0, 3),
         3 -> Eps(Seq(4, 5)),
-        4 -> Consume(Set(IChar('\n')), 1),
-        5 -> Consume(Set(IChar('a')), 6),
+        4 -> Consume(Set(IChar('\n').withLineTerminator), 1),
+        5 -> Consume(Set(IChar('a').withWord), 6),
         6 -> Eps(Seq(7, 1)),
         7 -> Assert(AssertKind.WordBoundaryNot, 1),
         8 -> LoopExit(0, 9),
@@ -135,7 +141,7 @@ class EpsNFASuite extends munit.FunSuite {
     assertEquals(
       nfa2.toOrderedNFA,
       OrderedNFA(
-        Set(IChar('\n'), IChar('a'), IChar('a').union(IChar('\n')).complement(false)),
+        Set(IChar('\n').withLineTerminator, IChar('a').withWord, IChar('a').union(IChar('\n')).complement(false)),
         Set(
           (CharInfo(true, false), Seq(4)),
           (CharInfo(true, false), Seq(4, 5)),
@@ -144,19 +150,19 @@ class EpsNFASuite extends munit.FunSuite {
         Vector((CharInfo(true, false), Seq(4))),
         Set((CharInfo(false, true), Seq(5, 4, 5, 10))),
         Map(
-          ((CharInfo(true, false), Seq(4)), IChar('\n')) -> Vector(
+          ((CharInfo(true, false), Seq(4)), IChar('\n').withLineTerminator) -> Vector(
             (CharInfo(true, false), Seq(4, 5))
           ),
-          ((CharInfo(true, false), Seq(4, 5)), IChar('a')) -> Vector(
+          ((CharInfo(true, false), Seq(4, 5)), IChar('a').withWord) -> Vector(
             (CharInfo(false, true), Seq(5, 4, 5, 10))
           ),
-          ((CharInfo(true, false), Seq(4, 5)), IChar('\n')) -> Vector(
+          ((CharInfo(true, false), Seq(4, 5)), IChar('\n').withLineTerminator) -> Vector(
             (CharInfo(true, false), Seq(4, 5))
           ),
-          ((CharInfo(false, true), Seq(5, 4, 5, 10)), IChar('\n')) -> Vector(
+          ((CharInfo(false, true), Seq(5, 4, 5, 10)), IChar('\n').withLineTerminator) -> Vector(
             (CharInfo(true, false), Seq(4, 5))
           ),
-          ((CharInfo(false, true), Seq(5, 4, 5, 10)), IChar('a')) -> Vector(
+          ((CharInfo(false, true), Seq(5, 4, 5, 10)), IChar('a').withWord) -> Vector(
             (CharInfo(false, true), Seq(5, 4, 5, 10)),
             (CharInfo(false, true), Seq(5, 4, 5, 10))
           )

--- a/modules/recheck/shared/src/test/scala/codes/quine/labo/recheck/data/ICharSetSuite.scala
+++ b/modules/recheck/shared/src/test/scala/codes/quine/labo/recheck/data/ICharSetSuite.scala
@@ -16,11 +16,11 @@ class ICharSetSuite extends munit.FunSuite {
 
   test("ICharSet#add") {
     assertEquals(
-      ICharSet.any(false, false).add(IChar(IntervalSet((UChar('A'), UChar('B'))))),
+      ICharSet.any(false, false).add(IChar(IntervalSet((UChar('A'), UChar('B'))), false, false)),
       ICharSet(
         Seq(
-          IChar(IntervalSet((UChar('A'), UChar('B')))),
-          IChar(IntervalSet((UChar(0), UChar('A')), (UChar('B'), UChar(0x10000))))
+          IChar(IntervalSet((UChar('A'), UChar('B'))), false, false),
+          IChar(IntervalSet((UChar(0), UChar('A')), (UChar('B'), UChar(0x10000))), false, false)
         )
       )
     )
@@ -29,13 +29,13 @@ class ICharSetSuite extends munit.FunSuite {
   test("ICharSet#refine") {
     val set = ICharSet
       .any(false, false)
-      .add(IChar(IntervalSet((UChar('A'), UChar('Z' + 1)))))
-      .add(IChar(IntervalSet((UChar('A'), UChar('A' + 1)))))
+      .add(IChar(IntervalSet((UChar('A'), UChar('Z' + 1))), false, true))
+      .add(IChar(IntervalSet((UChar('A'), UChar('A' + 1))), false, false))
     assertEquals(
-      set.refine(IChar(IntervalSet((UChar('A'), UChar('Z' + 1))))),
+      set.refine(IChar(IntervalSet((UChar('A'), UChar('Z' + 1))), false, true)),
       Set(
-        IChar(IntervalSet((UChar('A'), UChar('A' + 1)))),
-        IChar(IntervalSet((UChar('B'), UChar('Z' + 1))))
+        IChar(IntervalSet((UChar('A'), UChar('A' + 1))), false, true),
+        IChar(IntervalSet((UChar('B'), UChar('Z' + 1))), false, true)
       )
     )
   }
@@ -43,23 +43,25 @@ class ICharSetSuite extends munit.FunSuite {
   test("ICharSet#refineInvert") {
     val set = ICharSet
       .any(false, false)
-      .add(IChar(IntervalSet((UChar('A'), UChar('Z' + 1)))))
-      .add(IChar(IntervalSet((UChar('A'), UChar('A' + 1)))))
+      .add(IChar(IntervalSet((UChar('A'), UChar('Z' + 1))), false, true))
+      .add(IChar(IntervalSet((UChar('A'), UChar('A' + 1))), false, false))
     assertEquals(
-      set.refineInvert(IChar(IntervalSet((UChar('A'), UChar('Z' + 1))))),
-      Set(IChar(IntervalSet((UChar(0x00), UChar('A')), (UChar('Z' + 1), UChar(0x10000)))))
+      set.refineInvert(IChar(IntervalSet((UChar('A'), UChar('Z' + 1))), false, true)),
+      Set(
+        IChar(IntervalSet((UChar(0x00), UChar('A')), (UChar('Z' + 1), UChar(0x10000))), false, false)
+      )
     )
   }
 
   test("ICharSet#any") {
     val set = ICharSet
       .any(false, false)
-      .add(IChar(IntervalSet((UChar('A'), UChar('B')))))
+      .add(IChar(IntervalSet((UChar('A'), UChar('B'))), false, false))
     assertEquals(
       set.any,
       Set(
-        IChar(IntervalSet((UChar('A'), UChar('B')))),
-        IChar(IntervalSet((UChar(0), UChar('A')), (UChar('B'), UChar(0x10000))))
+        IChar(IntervalSet((UChar('A'), UChar('B'))), false, false),
+        IChar(IntervalSet((UChar(0), UChar('A')), (UChar('B'), UChar(0x10000))), false, false)
       )
     )
   }

--- a/modules/recheck/shared/src/test/scala/codes/quine/labo/recheck/data/ICharSuite.scala
+++ b/modules/recheck/shared/src/test/scala/codes/quine/labo/recheck/data/ICharSuite.scala
@@ -5,7 +5,7 @@ import codes.quine.labo.recheck.data.unicode.IntervalSet._
 
 class ICharSuite extends munit.FunSuite {
   test("IChar.Any") {
-    assertEquals(IChar.Any, IChar(IntervalSet((UChar(0), UChar(0x110000)))))
+    assertEquals(IChar.Any, IChar(IntervalSet((UChar(0), UChar(0x110000))), false, false))
   }
 
   test("IChar.Digit") {
@@ -52,7 +52,7 @@ class ICharSuite extends munit.FunSuite {
   }
 
   test("IChar.apply") {
-    assertEquals(IChar('a'), IChar(IntervalSet((UChar(0x61), UChar(0x62)))))
+    assertEquals(IChar('a'), IChar(IntervalSet((UChar(0x61), UChar(0x62))), false, false))
   }
 
   test("IChar.empty") {
@@ -100,29 +100,22 @@ class ICharSuite extends munit.FunSuite {
     assertEquals(IChar.canonicalize(IChar('\u017f'), true), IChar('s'))
   }
 
+  test("IChar#withLineTerminator") {
+    assert(IChar('\n').withLineTerminator.isLineTerminator)
+  }
+
+  test("IChar#withWord") {
+    assert(IChar('a').withWord.isWord)
+  }
+
   test("IChar#isEmpty") {
-    assert(IChar(IntervalSet.empty[UChar]).isEmpty)
-    assert(!IChar(IntervalSet((UChar(0x41), UChar(0x42)))).isEmpty)
+    assert(IChar(IntervalSet.empty, false, false).isEmpty)
+    assert(!IChar(IntervalSet((UChar(0x41), UChar(0x42))), false, false).isEmpty)
   }
 
   test("IChar#nonEmpty") {
-    assert(!IChar(IntervalSet.empty[UChar]).nonEmpty)
-    assert(IChar(IntervalSet((UChar(0x41), UChar(0x42)))).nonEmpty)
-  }
-
-  test("IChar#isLineTerminator") {
-    assert(IChar('\n').isLineTerminator)
-    assert(!IChar('a').isLineTerminator)
-  }
-
-  test("IChar#isWord") {
-    assert(!IChar('\n').isWord)
-    assert(IChar('a').isWord)
-  }
-
-  test("IChar#nonEmpty") {
-    assert(!IChar(IntervalSet.empty[UChar]).nonEmpty)
-    assert(IChar(IntervalSet((UChar(0x41), UChar(0x42)))).nonEmpty)
+    assert(!IChar(IntervalSet.empty, false, false).nonEmpty)
+    assert(IChar(IntervalSet((UChar(0x41), UChar(0x42))), false, false).nonEmpty)
   }
 
   test("IChar#complement") {
@@ -133,16 +126,17 @@ class ICharSuite extends munit.FunSuite {
   }
 
   test("IChar#union") {
-    assertEquals(IChar('a') union IChar('b'), IChar(IntervalSet((UChar('a'), UChar('c')))))
+    assertEquals(IChar('a') union IChar('b'), IChar(IntervalSet((UChar('a'), UChar('c'))), false, false))
   }
 
   test("IChar#partition") {
     assertEquals(
-      IChar(IntervalSet((UChar(0x41), UChar(0x42)))).partition(IChar(IntervalSet((UChar(0x41), UChar(0x5b))))),
+      IChar(IntervalSet((UChar(0x41), UChar(0x42))), true, false)
+        .partition(IChar(IntervalSet((UChar(0x41), UChar(0x5b))), false, true)),
       Partition(
-        IChar(IntervalSet((UChar(0x41), UChar(0x42)))),
-        IChar(IntervalSet.empty[UChar]),
-        IChar(IntervalSet((UChar(0x42), UChar(0x5b))))
+        IChar(IntervalSet((UChar(0x41), UChar(0x42))), true, true),
+        IChar(IntervalSet.empty, true, false),
+        IChar(IntervalSet((UChar(0x42), UChar(0x5b))), false, true)
       )
     )
   }
@@ -163,15 +157,25 @@ class ICharSuite extends munit.FunSuite {
   }
 
   test("IChar#compare") {
-    val c1 = IChar(IntervalSet((UChar(0x41), UChar(0x42))))
-    val c2 = IChar(IntervalSet((UChar(0x42), UChar(0x43))))
+    val c1 = IChar(IntervalSet((UChar(0x41), UChar(0x42))), false, false)
+    val c2 = IChar(IntervalSet((UChar(0x42), UChar(0x43))), false, false)
     assertEquals(c1.compare(c1), 0)
     assertEquals(c1.compare(c2), -1)
     assertEquals(c2.compare(c1), 1)
   }
 
   test("IChar#toString") {
-    assertEquals(IChar(IntervalSet((UChar('a'), UChar('b')), (UChar('A'), UChar('Z' + 1)))).toString, "[A-Za]")
-    assertEquals(IChar('\u0001').union(IChar('-')).union(IChar(UChar(0x10ffff))).toString, "[\\cA\\-\\u{10FFFF}]")
+    assertEquals(
+      IChar(IntervalSet((UChar('a'), UChar('b')), (UChar('A'), UChar('Z' + 1))), true, false).toString,
+      "[A-Za]n"
+    )
+    assertEquals(
+      IChar(IntervalSet((UChar('a'), UChar('z' + 1)), (UChar('A'), UChar('B'))), false, true).toString,
+      "[Aa-z]w"
+    )
+    assertEquals(
+      IChar('\u0001').union(IChar('-')).union(IChar(UChar(0x10ffff))).toString,
+      "[\\cA\\-\\u{10FFFF}]"
+    )
   }
 }

--- a/modules/recheck/shared/src/test/scala/codes/quine/labo/recheck/regexp/PatternSuite.scala
+++ b/modules/recheck/shared/src/test/scala/codes/quine/labo/recheck/regexp/PatternSuite.scala
@@ -321,8 +321,8 @@ class PatternSuite extends munit.FunSuite {
     val flagSet2 = FlagSet(false, false, false, true, false, false)
     val flagSet3 = FlagSet(false, true, false, false, false, false)
     val flagSet4 = FlagSet(false, true, false, false, true, false)
-    val word = IChar.Word
-    val lineTerminator = IChar.LineTerminator
+    val word = IChar.Word.withWord
+    val lineTerminator = IChar.LineTerminator.withLineTerminator
     val dot16 = IChar.Any16.diff(IChar.LineTerminator)
     val dot = IChar.Any.diff(IChar.LineTerminator)
     assertEquals(Pattern(Sequence(Seq.empty), flagSet0).alphabet, Success(ICharSet.any(false, false)))


### PR DESCRIPTION
Reverts MakeNowJust-Labo/recheck#62

Because this causes serious performance down on automaton based analysis, and sometimes it is buggy.
