### PR TITLE
Remove `isLineTerminator` and `isWord` flags from `IChar`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # dev
 
+Changes:
+
+- Remove `isLineTerminator` and `isWord` flags from `IChar`
+
 Fixes:
 
 - Fix nested look-around assertion behavior correctly

--- a/modules/recheck/shared/src/main/scala/codes/quine/labo/recheck/automaton/EpsNFA.scala
+++ b/modules/recheck/shared/src/main/scala/codes/quine/labo/recheck/automaton/EpsNFA.scala
@@ -8,6 +8,7 @@ import codes.quine.labo.recheck.common.Context
 import codes.quine.labo.recheck.common.UnsupportedException
 import codes.quine.labo.recheck.data.IChar
 import codes.quine.labo.recheck.data.ICharSet
+import codes.quine.labo.recheck.data.ICharSet.CharKind
 import codes.quine.labo.recheck.util.GraphvizUtil.escape
 
 /** EpsNFA is an ordered ε-NFA on unicode code points. */
@@ -51,74 +52,73 @@ final case class EpsNFA[Q](alphabet: ICharSet, stateSet: Set[Q], init: Q, accept
   }
 
   /** Converts this ε-NFA to ordered NFA with ε-elimination. */
-  def toOrderedNFA(implicit ctx: Context): OrderedNFA[IChar, (CharInfo, Seq[Q])] = toOrderedNFA(Int.MaxValue)
+  def toOrderedNFA(implicit ctx: Context): OrderedNFA[IChar, (CharKind, Seq[Q])] = toOrderedNFA(Int.MaxValue)
 
   /** Converts this ε-NFA to ordered NFA with ε-elimination. */
-  def toOrderedNFA(maxNFASize: Int)(implicit ctx: Context): OrderedNFA[IChar, (CharInfo, Seq[Q])] =
+  def toOrderedNFA(maxNFASize: Int)(implicit ctx: Context): OrderedNFA[IChar, (CharKind, Seq[Q])] =
     ctx.interrupt {
       // Obtains a set of possible character information.
-      // `CharInfo(true, false)` means a beginning or ending marker.
-      val charInfoSet = alphabet.chars.toSet.map(CharInfo.from) ++ Set(CharInfo(true, false))
+      // The last `CharKind.LineTerminator` means a beginning or ending marker.
+      val charInfoSet = alphabet.pairs.iterator.map(_._2).toSet ++ Set(CharKind.LineTerminator)
 
       /** Skips ε-transitions from the state and collects not ε-transition or terminal state. */
-      def buildClosure(c0: CharInfo, cs: Set[CharInfo], q: Q, loops: Set[Int]): Seq[(Q, Option[Consume[Q]])] =
+      def buildClosure(k0: CharKind, ks: Set[CharKind], q: Q, loops: Set[Int]): Seq[(Q, Option[Consume[Q]])] =
         ctx.interrupt {
-          if (cs.isEmpty) Vector.empty
+          if (ks.isEmpty) Vector.empty
           else
             tau.get(q) match {
-              case Some(Eps(qs))       => qs.flatMap(buildClosure(c0, cs, _, loops))
-              case Some(Assert(k, q1)) => buildClosure(c0, cs & k.toCharInfoSet(c0), q1, loops)
+              case Some(Eps(qs))       => qs.flatMap(buildClosure(k0, ks, _, loops))
+              case Some(Assert(k, q1)) => buildClosure(k0, ks & k.toCharInfoSet(k0), q1, loops)
               case Some(LoopEnter(loop, q1)) =>
                 if (loops.contains(loop)) Vector.empty // An ε-loop is detected.
-                else buildClosure(c0, cs, q1, loops ++ Set(loop))
+                else buildClosure(k0, ks, q1, loops ++ Set(loop))
               case Some(LoopExit(loop, q1)) =>
                 if (loops.contains(loop)) Vector.empty // An ε-loop is detected.
-                else buildClosure(c0, cs, q1, loops)
+                else buildClosure(k0, ks, q1, loops)
               case Some(Consume(chs, q1, pos)) =>
-                val newChs = chs.filter(ch => cs.contains(CharInfo.from(ch)))
+                val newChs = chs.filter { case (_, k) => ks.contains(k) }
                 if (newChs.nonEmpty) Vector((q, Some(Consume(newChs, q1, pos))))
                 else Vector.empty
               case None =>
-                if (cs.contains(CharInfo(true, false))) Vector((q, None))
+                if (ks.contains(CharKind.LineTerminator)) Vector((q, None))
                 else Vector.empty
             }
         }
-      val closureCache = mutable.Map.empty[(CharInfo, Q), Seq[(Q, Option[Consume[Q]])]]
-      def closure(c0: CharInfo, q: Q): Seq[(Q, Option[Consume[Q]])] =
-        closureCache.getOrElseUpdate((c0, q), buildClosure(c0, charInfoSet, q, Set.empty))
+      val closureCache = mutable.Map.empty[(CharKind, Q), Seq[(Q, Option[Consume[Q]])]]
+      def closure(k0: CharKind, q: Q): Seq[(Q, Option[Consume[Q]])] =
+        closureCache.getOrElseUpdate((k0, q), buildClosure(k0, charInfoSet, q, Set.empty))
 
-      val closureInit = closure(CharInfo(true, false), init)
+      val closureInit = closure(CharKind.LineTerminator, init)
 
-      val queue = mutable.Queue.empty[(CharInfo, Seq[(Q, Option[Consume[Q]])])]
-      val newStateSet = mutable.Set.empty[(CharInfo, Seq[Q])]
-      val newInits = Vector((CharInfo(true, false), closureInit.map(_._1)))
-      val newAcceptSet = Set.newBuilder[(CharInfo, Seq[Q])]
-      val newDelta = Map.newBuilder[((CharInfo, Seq[Q]), IChar), Seq[(CharInfo, Seq[Q])]]
+      val queue = mutable.Queue.empty[(CharKind, Seq[(Q, Option[Consume[Q]])])]
+      val newStateSet = mutable.Set.empty[(CharKind, Seq[Q])]
+      val newInits = Vector((CharKind.LineTerminator, closureInit.map(_._1)))
+      val newAcceptSet = Set.newBuilder[(CharKind, Seq[Q])]
+      val newDelta = Map.newBuilder[((CharKind, Seq[Q]), IChar), Seq[(CharKind, Seq[Q])]]
       val newSourcemap = mutable.Map
-        .empty[((CharInfo, Seq[Q]), IChar, (CharInfo, Seq[Q])), Seq[(Int, Int)]]
+        .empty[((CharKind, Seq[Q]), IChar, (CharKind, Seq[Q])), Seq[(Int, Int)]]
         .withDefaultValue(Vector.empty)
       var deltaSize = 0
 
-      queue.enqueue((CharInfo(true, false), closureInit))
+      queue.enqueue((CharKind.LineTerminator, closureInit))
       newStateSet.addAll(newInits)
 
       while (queue.nonEmpty) ctx.interrupt {
         val (c0, qps) = queue.dequeue()
         val qs0 = qps.map(_._1)
         if (qs0.contains(accept)) newAcceptSet.addOne((c0, qs0))
-        val d = mutable.Map.empty[IChar, Seq[(CharInfo, Seq[Q])]].withDefaultValue(Vector.empty)
+        val d = mutable.Map.empty[IChar, Seq[(CharKind, Seq[Q])]].withDefaultValue(Vector.empty)
         for ((_, p) <- qps) {
           p match {
             case Some(Consume(chs, q1, loc)) =>
-              for (ch <- chs) {
-                val c1 = CharInfo.from(ch)
-                val qps1 = closure(c1, q1)
+              for ((ch, k1) <- chs) {
+                val qps1 = closure(k1, q1)
                 val qs1 = qps1.map(_._1)
-                d(ch) = d(ch) :+ (c1, qs1)
-                newSourcemap(((c0, qs0), ch, (c1, qs1))) ++= loc
-                if (!newStateSet.contains((c1, qs1))) {
-                  queue.enqueue((c1, qps1))
-                  newStateSet.addOne((c1, qs1))
+                d(ch) = d(ch) :+ (k1, qs1)
+                newSourcemap(((c0, qs0), ch, (k1, qs1))) ++= loc
+                if (!newStateSet.contains((k1, qs1))) {
+                  queue.enqueue((k1, qps1))
+                  newStateSet.addOne((k1, qs1))
                 }
               }
             case None =>
@@ -131,7 +131,7 @@ final case class EpsNFA[Q](alphabet: ICharSet, stateSet: Set[Q], init: Q, accept
       }
 
       OrderedNFA(
-        alphabet.chars.toSet,
+        alphabet.any.map(_._1),
         newStateSet.toSet,
         newInits,
         newAcceptSet.result(),
@@ -154,7 +154,7 @@ object EpsNFA {
   final case class Assert[Q](kind: AssertKind, to: Q) extends Transition[Q]
 
   /** Consume is an ε-NFA transition with consuming a character. */
-  final case class Consume[Q](set: Set[IChar], to: Q, loc: Option[(Int, Int)] = None) extends Transition[Q]
+  final case class Consume[Q](set: Set[(IChar, CharKind)], to: Q, loc: Option[(Int, Int)] = None) extends Transition[Q]
 
   /** LoopEnter is an ε-NFA transition with consuming no character and marking a entering of the loop. */
   final case class LoopEnter[Q](loop: Int, to: Q) extends Transition[Q]
@@ -165,16 +165,8 @@ object EpsNFA {
   /** AssertKind is assertion kind of this ε-NFA transition. */
   sealed abstract class AssertKind extends Serializable with Product {
 
-    /** Tests the assertion on the around character information. */
-    def accepts(prev: CharInfo, next: CharInfo): Boolean = this match {
-      case AssertKind.LineBegin       => prev.isLineTerminator
-      case AssertKind.LineEnd         => next.isLineTerminator
-      case AssertKind.WordBoundary    => prev.isWord != next.isWord
-      case AssertKind.WordBoundaryNot => prev.isWord == next.isWord
-    }
-
     /** Returns a set of next possible character information from the previous character information. */
-    def toCharInfoSet(prev: CharInfo): Set[CharInfo]
+    def toCharInfoSet(prev: CharKind): Set[CharKind]
   }
 
   /** AssertKind values and utilities. */
@@ -182,42 +174,28 @@ object EpsNFA {
 
     /** LineBegin is `^` assertion. */
     case object LineBegin extends AssertKind {
-      def toCharInfoSet(prev: CharInfo): Set[CharInfo] =
-        if (prev.isLineTerminator) Set(CharInfo(false, false), CharInfo(false, true), CharInfo(true, false))
+      def toCharInfoSet(prev: CharKind): Set[CharKind] =
+        if (prev == CharKind.LineTerminator) Set(CharKind.Normal, CharKind.LineTerminator, CharKind.Word)
         else Set.empty
     }
 
     /** LineEnd is `$` assertion. */
     case object LineEnd extends AssertKind {
-      def toCharInfoSet(prev: CharInfo): Set[CharInfo] = Set(CharInfo(true, false))
+      def toCharInfoSet(prev: CharKind): Set[CharKind] = Set(CharKind.LineTerminator)
     }
 
     /** WordBoundary is `\b` assertion. */
     case object WordBoundary extends AssertKind {
-      def toCharInfoSet(prev: CharInfo): Set[CharInfo] =
-        if (prev.isWord) Set(CharInfo(false, false), CharInfo(true, false))
-        else Set(CharInfo(false, true))
+      def toCharInfoSet(prev: CharKind): Set[CharKind] =
+        if (prev == CharKind.Word) Set(CharKind.Normal, CharKind.LineTerminator)
+        else Set(CharKind.Word)
     }
 
     /** WordBoundaryNot is `\B` assertion. */
     case object WordBoundaryNot extends AssertKind {
-      def toCharInfoSet(prev: CharInfo): Set[CharInfo] =
-        if (prev.isWord) Set(CharInfo(false, true))
-        else Set(CharInfo(false, false), CharInfo(true, false))
+      def toCharInfoSet(prev: CharKind): Set[CharKind] =
+        if (prev == CharKind.Word) Set(CharKind.Word)
+        else Set(CharKind.Normal, CharKind.LineTerminator)
     }
-  }
-
-  /** CharInfo is a minimum character information for assertion check.
-    *
-    * Note that both of `isLineTerminator` and `isWord` must not be `true` at the same time
-    * because there is no character which is a line terminator and also a word.
-    */
-  final case class CharInfo(isLineTerminator: Boolean, isWord: Boolean)
-
-  /** CharInfo utilities. */
-  object CharInfo {
-
-    /** Extracts a character information from the interval set. */
-    def from(ch: IChar): CharInfo = CharInfo(ch.isLineTerminator, ch.isWord)
   }
 }

--- a/modules/recheck/shared/src/main/scala/codes/quine/labo/recheck/automaton/EpsNFA.scala
+++ b/modules/recheck/shared/src/main/scala/codes/quine/labo/recheck/automaton/EpsNFA.scala
@@ -68,7 +68,7 @@ final case class EpsNFA[Q](alphabet: ICharSet, stateSet: Set[Q], init: Q, accept
           else
             tau.get(q) match {
               case Some(Eps(qs))       => qs.flatMap(buildClosure(k0, ks, _, loops))
-              case Some(Assert(k, q1)) => buildClosure(k0, ks & k.toCharInfoSet(k0), q1, loops)
+              case Some(Assert(k, q1)) => buildClosure(k0, ks & k.toCharKindSet(k0), q1, loops)
               case Some(LoopEnter(loop, q1)) =>
                 if (loops.contains(loop)) Vector.empty // An ε-loop is detected.
                 else buildClosure(k0, ks, q1, loops ++ Set(loop))
@@ -166,7 +166,7 @@ object EpsNFA {
   sealed abstract class AssertKind extends Serializable with Product {
 
     /** Returns a set of next possible character information from the previous character information. */
-    def toCharInfoSet(prev: CharKind): Set[CharKind]
+    def toCharKindSet(prev: CharKind): Set[CharKind]
   }
 
   /** AssertKind values and utilities. */
@@ -174,26 +174,26 @@ object EpsNFA {
 
     /** LineBegin is `^` assertion. */
     case object LineBegin extends AssertKind {
-      def toCharInfoSet(prev: CharKind): Set[CharKind] =
+      def toCharKindSet(prev: CharKind): Set[CharKind] =
         if (prev == CharKind.LineTerminator) Set(CharKind.Normal, CharKind.LineTerminator, CharKind.Word)
         else Set.empty
     }
 
     /** LineEnd is `$` assertion. */
     case object LineEnd extends AssertKind {
-      def toCharInfoSet(prev: CharKind): Set[CharKind] = Set(CharKind.LineTerminator)
+      def toCharKindSet(prev: CharKind): Set[CharKind] = Set(CharKind.LineTerminator)
     }
 
     /** WordBoundary is `\b` assertion. */
     case object WordBoundary extends AssertKind {
-      def toCharInfoSet(prev: CharKind): Set[CharKind] =
+      def toCharKindSet(prev: CharKind): Set[CharKind] =
         if (prev == CharKind.Word) Set(CharKind.Normal, CharKind.LineTerminator)
         else Set(CharKind.Word)
     }
 
     /** WordBoundaryNot is `\B` assertion. */
     case object WordBoundaryNot extends AssertKind {
-      def toCharInfoSet(prev: CharKind): Set[CharKind] =
+      def toCharKindSet(prev: CharKind): Set[CharKind] =
         if (prev == CharKind.Word) Set(CharKind.Word)
         else Set(CharKind.Normal, CharKind.LineTerminator)
     }

--- a/modules/recheck/shared/src/main/scala/codes/quine/labo/recheck/automaton/EpsNFACompiler.scala
+++ b/modules/recheck/shared/src/main/scala/codes/quine/labo/recheck/automaton/EpsNFACompiler.scala
@@ -169,7 +169,7 @@ object EpsNFACompiler {
             val i4 = nextQ()
             tau.addOne(i1 -> Eps(Vector(i4, i2)))
             tau.addOne(i2 -> LoopEnter(loop, i3))
-            tau.addOne(i3 -> Consume(alphabet.chars.toSet, i1))
+            tau.addOne(i3 -> Consume(alphabet.any, i1))
             tau.addOne(i4 -> LoopExit(loop, i0))
             i1
           } else i0
@@ -181,7 +181,7 @@ object EpsNFACompiler {
             val a4 = nextQ()
             tau.addOne(a0 -> Eps(Vector(a3, a1)))
             tau.addOne(a1 -> LoopEnter(loop, a2))
-            tau.addOne(a2 -> Consume(alphabet.chars.toSet, a0))
+            tau.addOne(a2 -> Consume(alphabet.any, a0))
             tau.addOne(a3 -> LoopExit(loop, a4))
             a4
           } else a0

--- a/modules/recheck/shared/src/main/scala/codes/quine/labo/recheck/data/IChar.scala
+++ b/modules/recheck/shared/src/main/scala/codes/quine/labo/recheck/data/IChar.scala
@@ -7,17 +7,7 @@ import codes.quine.labo.recheck.data.unicode.IntervalSet._
 import codes.quine.labo.recheck.data.unicode.Property
 
 /** IChar is a code point interval set with extra information. */
-final case class IChar(
-    set: IntervalSet[UChar],
-    isLineTerminator: Boolean = false,
-    isWord: Boolean = false
-) extends Ordered[IChar] {
-
-  /** Marks this set contains line terminator characters. */
-  def withLineTerminator: IChar = copy(isLineTerminator = true)
-
-  /** Marks this set contains word characters. */
-  def withWord: IChar = copy(isWord = true)
+final case class IChar(set: IntervalSet[UChar]) extends Ordered[IChar] {
 
   /** Checks whether this interval set is empty or not. */
   def isEmpty: Boolean = set.isEmpty
@@ -30,18 +20,16 @@ final case class IChar(
     val (xys, z) = set.intervals.foldLeft((IndexedSeq.empty[(UChar, UChar)], UChar(0))) { case ((seq, x), (y, z)) =>
       (seq :+ (x, y), z)
     }
-    IChar(IntervalSet.from(xys :+ (z, UChar(if (unicode) 0x110000 else 0x10000))), isLineTerminator, isWord)
+    IChar(IntervalSet.from(xys :+ (z, UChar(if (unicode) 0x110000 else 0x10000))))
   }
 
   /** Computes a union of two interval sets. */
-  def union(that: IChar): IChar =
-    IChar(set.union(that.set), isLineTerminator || that.isLineTerminator, isWord || that.isWord)
+  def union(that: IChar): IChar = IChar(set.union(that.set))
 
   /** Computes a partition of two interval sets. */
   def partition(that: IChar): Partition[IChar] = {
     val Partition(is, ls, rs) = set.partition(that.set)
-    val ic = IChar(is, isLineTerminator || that.isLineTerminator, isWord || that.isWord)
-    Partition(ic, copy(set = ls), that.copy(set = rs))
+    Partition(IChar(is), IChar(ls), IChar(rs))
   }
 
   /** Computes a difference interval set. */
@@ -69,7 +57,7 @@ final case class IChar(
       case (x, y) if x.value + 1 == y.value => showUCharInClass(x)
       case (x, y)                           => s"${showUCharInClass(x)}-${showUCharInClass(UChar(y.value - 1))}"
     }
-    cls.mkString("[", "", "]" ++ (if (isLineTerminator) "n" else "") ++ (if (isWord) "w" else ""))
+    cls.mkString("[", "", "]")
   }
 }
 
@@ -78,7 +66,7 @@ object IChar {
 
   /** [[scala.math.Ordering]] instance for [[IChar]]. */
   private val ordering: Ordering[IChar] =
-    Ordering.by[IChar, IntervalSet[UChar]](_.set).orElseBy(_.isLineTerminator).orElseBy(_.isWord)
+    Ordering.by[IChar, IntervalSet[UChar]](_.set)
 
   /** Creates an interval set containing any code points. */
   lazy val Any: IChar = IChar(IntervalSet((UChar(0), UChar(0x110000))))

--- a/modules/recheck/shared/src/main/scala/codes/quine/labo/recheck/data/ICharSet.scala
+++ b/modules/recheck/shared/src/main/scala/codes/quine/labo/recheck/data/ICharSet.scala
@@ -1,37 +1,38 @@
 package codes.quine.labo.recheck.data
 
+import codes.quine.labo.recheck.data.ICharSet.CharKind
 import codes.quine.labo.recheck.data.unicode.IntervalSet._
 
-/** ICharSet is a set of [[IChar]]. */
-final case class ICharSet(chars: Seq[IChar]) {
+/** ICharSet is a set of pairs of an interval character and a character kind. */
+final case class ICharSet(pairs: Seq[(IChar, CharKind)]) {
 
   /** Updates this by adding the [[IChar]]. */
-  def add(c: IChar): ICharSet = {
-    val (cs, d) = chars.foldLeft((Vector.empty[IChar], c)) { case ((cs, c), d) =>
+  def add(c: IChar, k: CharKind = CharKind.Normal): ICharSet = {
+    val (cs, d) = pairs.foldLeft((Vector.empty[(IChar, CharKind)], c)) { case ((cs, c), (d, j)) =>
       val Partition(i, l, r) = c.partition(d)
-      (cs ++ Vector(i, r).filter(_.nonEmpty), l)
+      (cs ++ Vector((i, k.orElse(j)), (r, j)).filter(_._1.nonEmpty), l)
     }
-    ICharSet(cs ++ Vector(d).filter(_.nonEmpty))
+    ICharSet(cs ++ Vector((d, k)).filter(_._1.nonEmpty))
   }
 
-  /** Splits the [[IChar]] into refinements on this set.
+  /** Splits the specified interval character into refinements on this set.
     *
-    * Note the the [[IChar]] must add to the set before this method.
+    * Note the the interval character must be added to the set before this method.
     */
-  def refine(c: IChar): Set[IChar] =
-    chars.filter(d => c.set.intersection(d.set) == d.set).toSet
+  def refine(c: IChar): Set[(IChar, CharKind)] =
+    pairs.iterator.filter(d => c.set.intersection(d._1.set) == d._1.set).toSet
 
-  /** Splits the [[IChar]] into inverted refinements on this set. */
-  def refineInvert(c: IChar): Set[IChar] = any.diff(refine(c))
+  /** Splits the specified interval character into inverted refinements on this set. */
+  def refineInvert(c: IChar): Set[(IChar, CharKind)] = any.diff(refine(c))
 
   /** A character set for a 'any' pattern. */
-  def any: Set[IChar] = chars.toSet
+  def any: Set[(IChar, CharKind)] = pairs.toSet
 
   /** A character set for a 'dot' pattern. */
-  def dot: Set[IChar] = any.diff(newline)
+  def dot: Set[(IChar, CharKind)] = any.diff(newline)
 
   /** A character set for newline characters. */
-  def newline: Set[IChar] = refine(IChar.LineTerminator)
+  def newline: Set[(IChar, CharKind)] = refine(IChar.LineTerminator)
 }
 
 /** ICharSet utilities. */
@@ -39,5 +40,25 @@ object ICharSet {
 
   /** Creates a [[ICharSet]] containing any [[IChar]]s. */
   def any(ignoreCase: Boolean, unicode: Boolean): ICharSet =
-    ICharSet(Vector(IChar.dot(ignoreCase, true, unicode)))
+    ICharSet(Vector((IChar.dot(ignoreCase, true, unicode), CharKind.Normal)))
+
+  /** CharKind is a minimum character information for assertion check. */
+  sealed abstract class CharKind extends Product with Serializable {
+
+    /** Returns the left-most not normal character kind. */
+    def orElse(that: CharKind): CharKind =
+      if (this == CharKind.Normal) that else this
+  }
+
+  object CharKind {
+
+    /** A character kind for normal character. */
+    case object Normal extends CharKind
+
+    /** A character kind for line terminator character. */
+    case object LineTerminator extends CharKind
+
+    /** A character kind for word character. */
+    case object Word extends CharKind
+  }
 }

--- a/modules/recheck/shared/src/main/scala/codes/quine/labo/recheck/fuzz/FuzzChecker.scala
+++ b/modules/recheck/shared/src/main/scala/codes/quine/labo/recheck/fuzz/FuzzChecker.scala
@@ -193,8 +193,8 @@ private[fuzz] final class FuzzChecker(
 
     val fc = random.between(0, 2) match {
       case 0 =>
-        val idx = random.between(0, alphabet.chars.size)
-        val c = alphabet.chars(idx).head
+        val idx = random.between(0, alphabet.pairs.size)
+        val c = alphabet.pairs(idx)._1.head
         FString.Wrap(c)
       case 1 =>
         if (t.isEmpty) return None
@@ -239,8 +239,8 @@ private[fuzz] final class FuzzChecker(
     val pos = random.between(0, t.size)
     val fc = t(pos) match {
       case FString.Wrap(_) =>
-        val k = random.nextInt(alphabet.chars.size)
-        val c = alphabet.chars(k).head
+        val k = random.nextInt(alphabet.pairs.size)
+        val c = alphabet.pairs(k)._1.head
         FString.Wrap(c)
       case FString.Repeat(m0, size0) =>
         val m = random.between(0, 2) match {

--- a/modules/recheck/shared/src/main/scala/codes/quine/labo/recheck/fuzz/Seeder.scala
+++ b/modules/recheck/shared/src/main/scala/codes/quine/labo/recheck/fuzz/Seeder.scala
@@ -42,7 +42,7 @@ object Seeder {
 
       interrupt {
         queue.enqueue((UString.empty, None))
-        for (ch <- fuzz.alphabet.chars) {
+        for ((ch, _) <- fuzz.alphabet.pairs) {
           val s = UString(IndexedSeq(ch.head))
           queue.enqueue((s, None))
           added.add(s)
@@ -103,11 +103,11 @@ object Seeder {
     /** Builds a patch from a failed point. */
     def build(failed: FailedPoint, alphabet: ICharSet): Patch =
       failed.kind match {
-        case ReadKind.Any         => InsertChar(failed.pos, alphabet.any)
-        case ReadKind.Dot         => InsertChar(failed.pos, alphabet.dot)
+        case ReadKind.Any         => InsertChar(failed.pos, alphabet.any.map(_._1))
+        case ReadKind.Dot         => InsertChar(failed.pos, alphabet.dot.map(_._1))
         case ReadKind.Char(c)     => InsertChar(failed.pos, Set(IChar(c)))
-        case ReadKind.Class(s)    => InsertChar(failed.pos, alphabet.refine(s))
-        case ReadKind.ClassNot(s) => InsertChar(failed.pos, alphabet.refineInvert(s))
+        case ReadKind.Class(s)    => InsertChar(failed.pos, alphabet.refine(s).map(_._1))
+        case ReadKind.ClassNot(s) => InsertChar(failed.pos, alphabet.refineInvert(s).map(_._1))
         case ReadKind.Ref(_)      => InsertString(failed.pos, failed.capture.get)
       }
   }

--- a/modules/recheck/shared/src/test/scala/codes/quine/labo/recheck/automaton/AutomatonCheckerSuite.scala
+++ b/modules/recheck/shared/src/test/scala/codes/quine/labo/recheck/automaton/AutomatonCheckerSuite.scala
@@ -54,7 +54,7 @@ class AutomatonCheckerSuite extends munit.FunSuite {
       Success(
         Polynomial(
           2,
-          Witness(Seq((Seq(a, a), Seq(a, a))), Seq(a, other, a, a, a)),
+          Witness(Seq((Seq(other), Seq(a, a))), Seq(a, a)),
           Hotspot(Seq(Spot(2, 4, Heat), Spot(6, 7, Heat), Spot(8, 10, Heat)))
         )
       )
@@ -90,7 +90,7 @@ class AutomatonCheckerSuite extends munit.FunSuite {
       check("^(a|b|ab)*$", ""),
       Success(
         Exponential(
-          Witness(Seq((Seq(a), Seq(a, b))), Seq(other2)),
+          Witness(Seq((Seq(a), Seq(b, a, b, a))), Seq(other2)),
           Hotspot(Seq(Spot(2, 3, Heat), Spot(4, 5, Heat), Spot(6, 8, Heat)))
         )
       )
@@ -99,7 +99,7 @@ class AutomatonCheckerSuite extends munit.FunSuite {
       check("^(aa|b|aab)*$", ""),
       Success(
         Exponential(
-          Witness(Seq((Seq(a, a), Seq(b, a, a, b, a, a))), Seq(other2)),
+          Witness(Seq((Seq(a), Seq(a, a, a, b, a))), Seq(other2)),
           Hotspot(Seq(Spot(2, 4, Heat), Spot(5, 6, Heat), Spot(7, 10, Heat)))
         )
       )

--- a/modules/recheck/shared/src/test/scala/codes/quine/labo/recheck/automaton/EpsNFACompilerSuite.scala
+++ b/modules/recheck/shared/src/test/scala/codes/quine/labo/recheck/automaton/EpsNFACompilerSuite.scala
@@ -9,6 +9,7 @@ import codes.quine.labo.recheck.common.InvalidRegExpException
 import codes.quine.labo.recheck.common.UnsupportedException
 import codes.quine.labo.recheck.data.IChar
 import codes.quine.labo.recheck.data.ICharSet
+import codes.quine.labo.recheck.data.ICharSet.CharKind
 import codes.quine.labo.recheck.regexp.Pattern
 import codes.quine.labo.recheck.regexp.Pattern._
 
@@ -23,7 +24,7 @@ class EpsNFACompilerSuite extends munit.FunSuite {
     val flagSet2 = FlagSet(false, false, false, true, false, false)
     val flagSet3 = FlagSet(false, false, false, true, true, false)
 
-    test("EpsNFACompiler.compile: submaatch") {
+    test("EpsNFACompiler.compile: submatch") {
       assertEquals(
         EpsNFACompiler.compile(Pattern(LineEnd(), flagSet0)),
         Success(
@@ -36,7 +37,7 @@ class EpsNFACompilerSuite extends munit.FunSuite {
               0 -> Assert(AssertKind.LineEnd, 1),
               2 -> Eps(Seq(5, 3)),
               3 -> LoopEnter(0, 4),
-              4 -> Consume(Set(IChar.Any16), 2),
+              4 -> Consume(Set((IChar.Any16, CharKind.Normal)), 2),
               5 -> LoopExit(0, 0)
             )
           )
@@ -54,7 +55,7 @@ class EpsNFACompilerSuite extends munit.FunSuite {
               0 -> Assert(AssertKind.LineBegin, 1),
               1 -> Eps(Seq(4, 2)),
               2 -> LoopEnter(0, 3),
-              3 -> Consume(Set(IChar.Any16), 1),
+              3 -> Consume(Set((IChar.Any16, CharKind.Normal)), 1),
               4 -> LoopExit(0, 5)
             )
           )
@@ -103,7 +104,7 @@ class EpsNFACompilerSuite extends munit.FunSuite {
         EpsNFACompiler.compile(Pattern(Sequence(Seq(LineBegin(), WordBoundary(false), LineEnd())), flagSet0)),
         Success(
           EpsNFA(
-            ICharSet.any(false, false).add(IChar.Word.withWord),
+            ICharSet.any(false, false).add(IChar.Word, CharKind.Word),
             Set(0, 1, 2, 3, 4, 5),
             0,
             5,
@@ -121,7 +122,7 @@ class EpsNFACompilerSuite extends munit.FunSuite {
         EpsNFACompiler.compile(Pattern(Sequence(Seq(LineBegin(), WordBoundary(true), LineEnd())), flagSet0)),
         Success(
           EpsNFA(
-            ICharSet.any(false, false).add(IChar.Word.withWord),
+            ICharSet.any(false, false).add(IChar.Word, CharKind.Word),
             Set(0, 1, 2, 3, 4, 5),
             0,
             5,
@@ -149,7 +150,7 @@ class EpsNFACompilerSuite extends munit.FunSuite {
             Map(
               0 -> Assert(AssertKind.LineBegin, 1),
               1 -> Eps(Seq(2)),
-              2 -> Consume(Set(IChar.canonicalize(IChar('a'), false)), 3),
+              2 -> Consume(Set((IChar.canonicalize(IChar('a'), false), CharKind.Normal)), 3),
               3 -> Eps(Seq(4)),
               4 -> Assert(AssertKind.LineEnd, 5)
             )
@@ -169,7 +170,7 @@ class EpsNFACompilerSuite extends munit.FunSuite {
             Map(
               0 -> Assert(AssertKind.LineBegin, 1),
               1 -> Eps(Seq(2)),
-              2 -> Consume(Set(IChar('a')), 3),
+              2 -> Consume(Set((IChar('a'), CharKind.Normal)), 3),
               3 -> Eps(Seq(4)),
               4 -> Assert(AssertKind.LineEnd, 5)
             )
@@ -189,7 +190,7 @@ class EpsNFACompilerSuite extends munit.FunSuite {
             Map(
               0 -> Assert(AssertKind.LineBegin, 1),
               1 -> Eps(Seq(2)),
-              2 -> Consume(Set(IChar.Any16.diff(IChar('a'))), 3),
+              2 -> Consume(Set((IChar.Any16.diff(IChar('a')), CharKind.Normal)), 3),
               3 -> Eps(Seq(4)),
               4 -> Assert(AssertKind.LineEnd, 5)
             )
@@ -210,7 +211,7 @@ class EpsNFACompilerSuite extends munit.FunSuite {
             Map(
               0 -> Assert(AssertKind.LineBegin, 1),
               1 -> Eps(Seq(2)),
-              2 -> Consume(Set(IChar.Any16.diff(IChar.LineTerminator)), 3),
+              2 -> Consume(Set((IChar.Any16.diff(IChar.LineTerminator), CharKind.Normal)), 3),
               3 -> Eps(Seq(4)),
               4 -> Assert(AssertKind.LineEnd, 5)
             )
@@ -228,7 +229,10 @@ class EpsNFACompilerSuite extends munit.FunSuite {
             Map(
               0 -> Assert(AssertKind.LineBegin, 1),
               1 -> Eps(Seq(2)),
-              2 -> Consume(Set(IChar.canonicalize(IChar.Any16.diff(IChar.LineTerminator), false)), 3),
+              2 -> Consume(
+                Set((IChar.canonicalize(IChar.Any16.diff(IChar.LineTerminator), false), CharKind.Normal)),
+                3
+              ),
               3 -> Eps(Seq(4)),
               4 -> Assert(AssertKind.LineEnd, 5)
             )
@@ -246,7 +250,7 @@ class EpsNFACompilerSuite extends munit.FunSuite {
             Map(
               0 -> Assert(AssertKind.LineBegin, 1),
               1 -> Eps(Seq(2)),
-              2 -> Consume(Set(IChar.Any16), 3),
+              2 -> Consume(Set((IChar.Any16, CharKind.Normal)), 3),
               3 -> Eps(Seq(4)),
               4 -> Assert(AssertKind.LineEnd, 5)
             )
@@ -264,7 +268,7 @@ class EpsNFACompilerSuite extends munit.FunSuite {
             Map(
               0 -> Assert(AssertKind.LineBegin, 1),
               1 -> Eps(Seq(2)),
-              2 -> Consume(Set(IChar.Any), 3),
+              2 -> Consume(Set((IChar.Any, CharKind.Normal)), 3),
               3 -> Eps(Seq(4)),
               4 -> Assert(AssertKind.LineEnd, 5)
             )
@@ -288,9 +292,9 @@ class EpsNFACompilerSuite extends munit.FunSuite {
               0 -> Assert(AssertKind.LineBegin, 1),
               1 -> Eps(Seq(6)),
               6 -> Eps(Seq(2, 4)),
-              2 -> Consume(Set(IChar.Any16), 3),
+              2 -> Consume(Set((IChar.Any16, CharKind.Normal)), 3),
               3 -> Eps(Seq(7)),
-              4 -> Consume(Set(IChar.Any16), 5),
+              4 -> Consume(Set((IChar.Any16, CharKind.Normal)), 5),
               5 -> Eps(Seq(7)),
               7 -> Eps(Seq(8)),
               8 -> Assert(AssertKind.LineEnd, 9)
@@ -314,7 +318,7 @@ class EpsNFACompilerSuite extends munit.FunSuite {
               1 -> Eps(Seq(4)),
               4 -> Eps(Seq(5, 6)),
               5 -> LoopEnter(0, 2),
-              2 -> Consume(Set(IChar.Any16), 3),
+              2 -> Consume(Set((IChar.Any16, CharKind.Normal)), 3),
               3 -> Eps(Seq(4)),
               6 -> LoopExit(0, 7),
               7 -> Eps(Seq(8)),
@@ -336,7 +340,7 @@ class EpsNFACompilerSuite extends munit.FunSuite {
               1 -> Eps(Seq(4)),
               4 -> Eps(Seq(6, 5)),
               5 -> LoopEnter(0, 2),
-              2 -> Consume(Set(IChar.Any16), 3),
+              2 -> Consume(Set((IChar.Any16, CharKind.Normal)), 3),
               3 -> Eps(Seq(4)),
               6 -> LoopExit(0, 7),
               7 -> Eps(Seq(8)),
@@ -359,7 +363,7 @@ class EpsNFACompilerSuite extends munit.FunSuite {
             Map(
               0 -> Assert(AssertKind.LineBegin, 1),
               1 -> Eps(Seq(2)),
-              2 -> Consume(Set(IChar.Any16), 3),
+              2 -> Consume(Set((IChar.Any16, CharKind.Normal)), 3),
               3 -> Eps(Seq(4, 5)),
               4 -> LoopEnter(0, 2),
               5 -> LoopExit(0, 6),
@@ -380,7 +384,7 @@ class EpsNFACompilerSuite extends munit.FunSuite {
             Map(
               0 -> Assert(AssertKind.LineBegin, 1),
               1 -> Eps(Seq(2)),
-              2 -> Consume(Set(IChar.Any16), 3),
+              2 -> Consume(Set((IChar.Any16, CharKind.Normal)), 3),
               3 -> Eps(Seq(5, 4)),
               4 -> LoopEnter(0, 2),
               5 -> LoopExit(0, 6),
@@ -405,7 +409,7 @@ class EpsNFACompilerSuite extends munit.FunSuite {
               0 -> Assert(AssertKind.LineBegin, 1),
               1 -> Eps(Seq(4)),
               4 -> Eps(Seq(2, 3)),
-              2 -> Consume(Set(IChar.Any16), 3),
+              2 -> Consume(Set((IChar.Any16, CharKind.Normal)), 3),
               3 -> Eps(Seq(5)),
               5 -> Assert(AssertKind.LineEnd, 6)
             )
@@ -424,7 +428,7 @@ class EpsNFACompilerSuite extends munit.FunSuite {
               0 -> Assert(AssertKind.LineBegin, 1),
               1 -> Eps(Seq(4)),
               4 -> Eps(Seq(3, 2)),
-              2 -> Consume(Set(IChar.Any16), 3),
+              2 -> Consume(Set((IChar.Any16, CharKind.Normal)), 3),
               3 -> Eps(Seq(5)),
               5 -> Assert(AssertKind.LineEnd, 6)
             )
@@ -433,7 +437,7 @@ class EpsNFACompilerSuite extends munit.FunSuite {
       )
     }
 
-    test("EpsNFACompiler.commpile: Repeat") {
+    test("EpsNFACompiler.compile: Repeat") {
       assertEquals(
         EpsNFACompiler.compile(Pattern(Sequence(Seq(LineBegin(), Repeat(false, 1, None, Dot()), LineEnd())), flagSet2)),
         EpsNFACompiler.compile(Pattern(Sequence(Seq(LineBegin(), Dot(), LineEnd())), flagSet2))
@@ -521,7 +525,7 @@ class EpsNFACompilerSuite extends munit.FunSuite {
         Map(
           0 -> Assert(AssertKind.LineBegin, 1),
           1 -> Eps(Seq(2)),
-          2 -> Consume(Set(IChar('a')), 3),
+          2 -> Consume(Set((IChar('a'), CharKind.Normal)), 3),
           3 -> Eps(Seq(4)),
           4 -> Assert(AssertKind.LineEnd, 5)
         )

--- a/modules/recheck/shared/src/test/scala/codes/quine/labo/recheck/automaton/EpsNFASuite.scala
+++ b/modules/recheck/shared/src/test/scala/codes/quine/labo/recheck/automaton/EpsNFASuite.scala
@@ -8,49 +8,29 @@ import codes.quine.labo.recheck.common.Context
 import codes.quine.labo.recheck.common.UnsupportedException
 import codes.quine.labo.recheck.data.IChar
 import codes.quine.labo.recheck.data.ICharSet
+import codes.quine.labo.recheck.data.ICharSet.CharKind
 
 class EpsNFASuite extends munit.FunSuite {
 
   /** A default context. */
   implicit def ctx: Context = Context()
 
-  test("EpsNFA.AssertKind#accepts") {
-    assert(AssertKind.LineBegin.accepts(CharInfo(true, false), CharInfo(false, false)))
-    assert(!AssertKind.LineBegin.accepts(CharInfo(false, false), CharInfo(false, false)))
-    assert(AssertKind.LineEnd.accepts(CharInfo(false, false), CharInfo(true, false)))
-    assert(!AssertKind.LineEnd.accepts(CharInfo(false, false), CharInfo(false, false)))
-    assert(AssertKind.WordBoundary.accepts(CharInfo(false, true), CharInfo(false, false)))
-    assert(AssertKind.WordBoundary.accepts(CharInfo(false, false), CharInfo(false, true)))
-    assert(!AssertKind.WordBoundary.accepts(CharInfo(false, false), CharInfo(false, false)))
-    assert(!AssertKind.WordBoundary.accepts(CharInfo(false, true), CharInfo(false, true)))
-    assert(AssertKind.WordBoundaryNot.accepts(CharInfo(false, false), CharInfo(false, false)))
-    assert(AssertKind.WordBoundaryNot.accepts(CharInfo(false, true), CharInfo(false, true)))
-    assert(!AssertKind.WordBoundaryNot.accepts(CharInfo(false, true), CharInfo(false, false)))
-    assert(!AssertKind.WordBoundaryNot.accepts(CharInfo(false, false), CharInfo(false, true)))
-  }
-
-  test("EpsNFA.AssertKind#toCharInfoSet") {
-    val neutral = CharInfo(false, false)
-    val lineTerminator = CharInfo(true, false)
-    val word = CharInfo(false, true)
-    assertEquals(AssertKind.LineBegin.toCharInfoSet(neutral), Set.empty[CharInfo])
-    assertEquals(AssertKind.LineBegin.toCharInfoSet(lineTerminator), Set(neutral, lineTerminator, word))
-    assertEquals(AssertKind.LineBegin.toCharInfoSet(word), Set.empty[CharInfo])
-    assertEquals(AssertKind.LineEnd.toCharInfoSet(neutral), Set(lineTerminator))
-    assertEquals(AssertKind.LineEnd.toCharInfoSet(lineTerminator), Set(lineTerminator))
-    assertEquals(AssertKind.LineEnd.toCharInfoSet(word), Set(lineTerminator))
-    assertEquals(AssertKind.WordBoundary.toCharInfoSet(neutral), Set(word))
-    assertEquals(AssertKind.WordBoundary.toCharInfoSet(lineTerminator), Set(word))
-    assertEquals(AssertKind.WordBoundary.toCharInfoSet(word), Set(neutral, lineTerminator))
-    assertEquals(AssertKind.WordBoundaryNot.toCharInfoSet(neutral), Set(neutral, lineTerminator))
-    assertEquals(AssertKind.WordBoundaryNot.toCharInfoSet(lineTerminator), Set(neutral, lineTerminator))
-    assertEquals(AssertKind.WordBoundaryNot.toCharInfoSet(word), Set(word))
-  }
-
-  test("EpsNFA.CharInfo.from") {
-    assertEquals(CharInfo.from(IChar('a')), CharInfo(false, false))
-    assertEquals(CharInfo.from(IChar('a').withLineTerminator), CharInfo(true, false))
-    assertEquals(CharInfo.from(IChar('a').withWord), CharInfo(false, true))
+  test("EpsNFA.AssertKind#toCharKindSet") {
+    val Normal: CharKind = CharKind.Normal
+    val LineTerminator: CharKind = CharKind.LineTerminator
+    val Word: CharKind = CharKind.Word
+    assertEquals(AssertKind.LineBegin.toCharKindSet(Normal), Set.empty[CharKind])
+    assertEquals(AssertKind.LineBegin.toCharKindSet(LineTerminator), Set(Normal, LineTerminator, Word))
+    assertEquals(AssertKind.LineBegin.toCharKindSet(Word), Set.empty[CharKind])
+    assertEquals(AssertKind.LineEnd.toCharKindSet(Normal), Set(LineTerminator))
+    assertEquals(AssertKind.LineEnd.toCharKindSet(LineTerminator), Set(LineTerminator))
+    assertEquals(AssertKind.LineEnd.toCharKindSet(Word), Set(LineTerminator))
+    assertEquals(AssertKind.WordBoundary.toCharKindSet(Normal), Set(Word))
+    assertEquals(AssertKind.WordBoundary.toCharKindSet(LineTerminator), Set(Word))
+    assertEquals(AssertKind.WordBoundary.toCharKindSet(Word), Set(Normal, LineTerminator))
+    assertEquals(AssertKind.WordBoundaryNot.toCharKindSet(Normal), Set(Normal, LineTerminator))
+    assertEquals(AssertKind.WordBoundaryNot.toCharKindSet(LineTerminator), Set(Normal, LineTerminator))
+    assertEquals(AssertKind.WordBoundaryNot.toCharKindSet(Word), Set(Word))
   }
 
   test("EpsNFA#toGraphviz") {
@@ -62,7 +42,7 @@ class EpsNFASuite extends munit.FunSuite {
       Map(
         0 -> Eps(Seq(1)),
         1 -> Eps(Seq(2, 3)),
-        2 -> Consume(Set(IChar('a')), 4),
+        2 -> Consume(Set((IChar('a'), CharKind.Normal)), 4),
         3 -> Assert(AssertKind.LineBegin, 4),
         4 -> LoopEnter(0, 5),
         5 -> LoopExit(0, 6)
@@ -79,7 +59,7 @@ class EpsNFASuite extends munit.FunSuite {
          |  "1" -> "2" [label=0];
          |  "1" -> "3" [label=1];
          |  "2" [shape=circle];
-         |  "2" -> "4" [label="{[a]}"];
+         |  "2" -> "4" [label="{([a],Normal)}"];
          |  "3" [shape=circle];
          |  "3" -> "4" [label="LineBegin"];
          |  "4" [shape=circle];
@@ -93,7 +73,7 @@ class EpsNFASuite extends munit.FunSuite {
 
   test("EpsNFA#toOrderedNFA") {
     val nfa1 = EpsNFA(
-      ICharSet.any(false, false).add(IChar('\n').withLineTerminator),
+      ICharSet.any(false, false).add(IChar('\n'), CharKind.LineTerminator),
       Set(0, 1, 2, 3, 4, 5, 6),
       0,
       6,
@@ -101,27 +81,27 @@ class EpsNFASuite extends munit.FunSuite {
         0 -> Eps(Seq(1, 5)),
         1 -> LoopEnter(0, 2),
         2 -> Eps(Seq(3, 4)),
-        3 -> Consume(Set(IChar('\n').withLineTerminator), 0),
+        3 -> Consume(Set((IChar('\n'), CharKind.LineTerminator)), 0),
         4 -> Assert(AssertKind.LineEnd, 0),
         5 -> LoopExit(0, 6)
       )
     )
     assertEquals(
       nfa1.toOrderedNFA,
-      OrderedNFA(
-        Set(IChar('\n').withLineTerminator, IChar('\n').complement(false)),
-        Set((CharInfo(true, false), Seq(3, 6))),
-        Vector((CharInfo(true, false), Seq(3, 6))),
-        Set((CharInfo(true, false), Seq(3, 6))),
+      OrderedNFA[IChar, (CharKind, Seq[Int])](
+        Set(IChar('\n'), IChar('\n').complement(false)),
+        Set((CharKind.LineTerminator, Seq(3, 6))),
+        Vector((CharKind.LineTerminator, Seq(3, 6))),
+        Set((CharKind.LineTerminator, Seq(3, 6))),
         Map(
-          ((CharInfo(true, false), Seq(3, 6)), IChar('\n').withLineTerminator) -> Vector(
-            (CharInfo(true, false), Seq(3, 6))
+          ((CharKind.LineTerminator, Seq(3, 6)), IChar('\n')) -> Vector(
+            (CharKind.LineTerminator, Seq(3, 6))
           )
         )
       )
     )
     val nfa2 = EpsNFA(
-      ICharSet.any(false, false).add(IChar('\n').withLineTerminator).add(IChar('a').withWord),
+      ICharSet.any(false, false).add(IChar('\n'), CharKind.LineTerminator).add(IChar('a'), CharKind.Word),
       Set(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
       0,
       10,
@@ -130,8 +110,8 @@ class EpsNFASuite extends munit.FunSuite {
         1 -> Eps(Seq(2, 8)),
         2 -> LoopEnter(0, 3),
         3 -> Eps(Seq(4, 5)),
-        4 -> Consume(Set(IChar('\n').withLineTerminator), 1),
-        5 -> Consume(Set(IChar('a').withWord), 6),
+        4 -> Consume(Set((IChar('\n'), CharKind.LineTerminator)), 1),
+        5 -> Consume(Set((IChar('a'), CharKind.Word)), 6),
         6 -> Eps(Seq(7, 1)),
         7 -> Assert(AssertKind.WordBoundaryNot, 1),
         8 -> LoopExit(0, 9),
@@ -141,30 +121,30 @@ class EpsNFASuite extends munit.FunSuite {
     assertEquals(
       nfa2.toOrderedNFA,
       OrderedNFA(
-        Set(IChar('\n').withLineTerminator, IChar('a').withWord, IChar('a').union(IChar('\n')).complement(false)),
+        Set(IChar('\n'), IChar('a'), IChar('a').union(IChar('\n')).complement(false)),
         Set(
-          (CharInfo(true, false), Seq(4)),
-          (CharInfo(true, false), Seq(4, 5)),
-          (CharInfo(false, true), Seq(5, 4, 5, 10))
+          (CharKind.LineTerminator, Seq(4)),
+          (CharKind.LineTerminator, Seq(4, 5)),
+          (CharKind.Word, Seq(5, 4, 5, 10))
         ),
-        Vector((CharInfo(true, false), Seq(4))),
-        Set((CharInfo(false, true), Seq(5, 4, 5, 10))),
+        Vector((CharKind.LineTerminator, Seq(4))),
+        Set((CharKind.Word: CharKind, Seq(5, 4, 5, 10))),
         Map(
-          ((CharInfo(true, false), Seq(4)), IChar('\n').withLineTerminator) -> Vector(
-            (CharInfo(true, false), Seq(4, 5))
+          ((CharKind.LineTerminator, Seq(4)), IChar('\n')) -> Vector(
+            (CharKind.LineTerminator, Seq(4, 5))
           ),
-          ((CharInfo(true, false), Seq(4, 5)), IChar('a').withWord) -> Vector(
-            (CharInfo(false, true), Seq(5, 4, 5, 10))
+          ((CharKind.LineTerminator, Seq(4, 5)), IChar('a')) -> Vector(
+            (CharKind.Word, Seq(5, 4, 5, 10))
           ),
-          ((CharInfo(true, false), Seq(4, 5)), IChar('\n').withLineTerminator) -> Vector(
-            (CharInfo(true, false), Seq(4, 5))
+          ((CharKind.LineTerminator, Seq(4, 5)), IChar('\n')) -> Vector(
+            (CharKind.LineTerminator, Seq(4, 5))
           ),
-          ((CharInfo(false, true), Seq(5, 4, 5, 10)), IChar('\n').withLineTerminator) -> Vector(
-            (CharInfo(true, false), Seq(4, 5))
+          ((CharKind.Word, Seq(5, 4, 5, 10)), IChar('\n')) -> Vector(
+            (CharKind.LineTerminator, Seq(4, 5))
           ),
-          ((CharInfo(false, true), Seq(5, 4, 5, 10)), IChar('a').withWord) -> Vector(
-            (CharInfo(false, true), Seq(5, 4, 5, 10)),
-            (CharInfo(false, true), Seq(5, 4, 5, 10))
+          ((CharKind.Word, Seq(5, 4, 5, 10)), IChar('a')) -> Vector(
+            (CharKind.Word, Seq(5, 4, 5, 10)),
+            (CharKind.Word, Seq(5, 4, 5, 10))
           )
         )
       )

--- a/modules/recheck/shared/src/test/scala/codes/quine/labo/recheck/data/ICharSetSuite.scala
+++ b/modules/recheck/shared/src/test/scala/codes/quine/labo/recheck/data/ICharSetSuite.scala
@@ -1,26 +1,27 @@
 package codes.quine.labo.recheck.data
 
+import codes.quine.labo.recheck.data.ICharSet.CharKind
 import codes.quine.labo.recheck.data.unicode.IntervalSet
 
 class ICharSetSuite extends munit.FunSuite {
   test("ICharSet.any") {
-    assertEquals(ICharSet.any(false, true).chars, Seq(IChar.Any))
-    assertEquals(ICharSet.any(false, false).chars, Seq(IChar.Any16))
+    assertEquals(ICharSet.any(false, true).pairs, Seq((IChar.Any, CharKind.Normal)))
+    assertEquals(ICharSet.any(false, false).pairs, Seq((IChar.Any16, CharKind.Normal)))
 
-    assert(ICharSet.any(true, false).chars.head.contains(UChar('A')))
-    assert(!ICharSet.any(true, false).chars.head.contains(UChar('a')))
+    assert(ICharSet.any(true, false).pairs.head._1.contains(UChar('A')))
+    assert(!ICharSet.any(true, false).pairs.head._1.contains(UChar('a')))
 
-    assert(ICharSet.any(true, true).chars.head.contains(UChar('s')))
-    assert(!ICharSet.any(true, true).chars.head.contains(UChar(0x017f)))
+    assert(ICharSet.any(true, true).pairs.head._1.contains(UChar('s')))
+    assert(!ICharSet.any(true, true).pairs.head._1.contains(UChar(0x017f)))
   }
 
   test("ICharSet#add") {
     assertEquals(
-      ICharSet.any(false, false).add(IChar(IntervalSet((UChar('A'), UChar('B'))), false, false)),
+      ICharSet.any(false, false).add(IChar(IntervalSet((UChar('A'), UChar('B'))))),
       ICharSet(
         Seq(
-          IChar(IntervalSet((UChar('A'), UChar('B'))), false, false),
-          IChar(IntervalSet((UChar(0), UChar('A')), (UChar('B'), UChar(0x10000))), false, false)
+          (IChar(IntervalSet((UChar('A'), UChar('B')))), CharKind.Normal),
+          (IChar(IntervalSet((UChar(0), UChar('A')), (UChar('B'), UChar(0x10000)))), CharKind.Normal)
         )
       )
     )
@@ -29,13 +30,13 @@ class ICharSetSuite extends munit.FunSuite {
   test("ICharSet#refine") {
     val set = ICharSet
       .any(false, false)
-      .add(IChar(IntervalSet((UChar('A'), UChar('Z' + 1))), false, true))
-      .add(IChar(IntervalSet((UChar('A'), UChar('A' + 1))), false, false))
+      .add(IChar(IntervalSet((UChar('A'), UChar('Z' + 1)))), CharKind.Word)
+      .add(IChar(IntervalSet((UChar('A'), UChar('A' + 1)))))
     assertEquals(
-      set.refine(IChar(IntervalSet((UChar('A'), UChar('Z' + 1))), false, true)),
+      set.refine(IChar(IntervalSet((UChar('A'), UChar('Z' + 1))))),
       Set(
-        IChar(IntervalSet((UChar('A'), UChar('A' + 1))), false, true),
-        IChar(IntervalSet((UChar('B'), UChar('Z' + 1))), false, true)
+        (IChar(IntervalSet((UChar('A'), UChar('A' + 1)))), CharKind.Word: CharKind),
+        (IChar(IntervalSet((UChar('B'), UChar('Z' + 1)))), CharKind.Word)
       )
     )
   }
@@ -43,12 +44,12 @@ class ICharSetSuite extends munit.FunSuite {
   test("ICharSet#refineInvert") {
     val set = ICharSet
       .any(false, false)
-      .add(IChar(IntervalSet((UChar('A'), UChar('Z' + 1))), false, true))
-      .add(IChar(IntervalSet((UChar('A'), UChar('A' + 1))), false, false))
+      .add(IChar(IntervalSet((UChar('A'), UChar('Z' + 1)))), CharKind.Word)
+      .add(IChar(IntervalSet((UChar('A'), UChar('A' + 1)))))
     assertEquals(
-      set.refineInvert(IChar(IntervalSet((UChar('A'), UChar('Z' + 1))), false, true)),
+      set.refineInvert(IChar(IntervalSet((UChar('A'), UChar('Z' + 1))))),
       Set(
-        IChar(IntervalSet((UChar(0x00), UChar('A')), (UChar('Z' + 1), UChar(0x10000))), false, false)
+        (IChar(IntervalSet((UChar(0x00), UChar('A')), (UChar('Z' + 1), UChar(0x10000)))), CharKind.Normal: CharKind)
       )
     )
   }
@@ -56,12 +57,12 @@ class ICharSetSuite extends munit.FunSuite {
   test("ICharSet#any") {
     val set = ICharSet
       .any(false, false)
-      .add(IChar(IntervalSet((UChar('A'), UChar('B'))), false, false))
+      .add(IChar(IntervalSet((UChar('A'), UChar('B')))))
     assertEquals(
       set.any,
       Set(
-        IChar(IntervalSet((UChar('A'), UChar('B'))), false, false),
-        IChar(IntervalSet((UChar(0), UChar('A')), (UChar('B'), UChar(0x10000))), false, false)
+        (IChar(IntervalSet((UChar('A'), UChar('B')))), CharKind.Normal: CharKind),
+        (IChar(IntervalSet((UChar(0), UChar('A')), (UChar('B'), UChar(0x10000)))), CharKind.Normal)
       )
     )
   }

--- a/modules/recheck/shared/src/test/scala/codes/quine/labo/recheck/data/ICharSuite.scala
+++ b/modules/recheck/shared/src/test/scala/codes/quine/labo/recheck/data/ICharSuite.scala
@@ -5,7 +5,7 @@ import codes.quine.labo.recheck.data.unicode.IntervalSet._
 
 class ICharSuite extends munit.FunSuite {
   test("IChar.Any") {
-    assertEquals(IChar.Any, IChar(IntervalSet((UChar(0), UChar(0x110000))), false, false))
+    assertEquals(IChar.Any, IChar(IntervalSet((UChar(0), UChar(0x110000)))))
   }
 
   test("IChar.Digit") {
@@ -52,7 +52,7 @@ class ICharSuite extends munit.FunSuite {
   }
 
   test("IChar.apply") {
-    assertEquals(IChar('a'), IChar(IntervalSet((UChar(0x61), UChar(0x62))), false, false))
+    assertEquals(IChar('a'), IChar(IntervalSet((UChar(0x61), UChar(0x62)))))
   }
 
   test("IChar.empty") {
@@ -100,22 +100,14 @@ class ICharSuite extends munit.FunSuite {
     assertEquals(IChar.canonicalize(IChar('\u017f'), true), IChar('s'))
   }
 
-  test("IChar#withLineTerminator") {
-    assert(IChar('\n').withLineTerminator.isLineTerminator)
-  }
-
-  test("IChar#withWord") {
-    assert(IChar('a').withWord.isWord)
-  }
-
   test("IChar#isEmpty") {
-    assert(IChar(IntervalSet.empty, false, false).isEmpty)
-    assert(!IChar(IntervalSet((UChar(0x41), UChar(0x42))), false, false).isEmpty)
+    assert(IChar(IntervalSet.empty[UChar]).isEmpty)
+    assert(!IChar(IntervalSet((UChar(0x41), UChar(0x42)))).isEmpty)
   }
 
   test("IChar#nonEmpty") {
-    assert(!IChar(IntervalSet.empty, false, false).nonEmpty)
-    assert(IChar(IntervalSet((UChar(0x41), UChar(0x42))), false, false).nonEmpty)
+    assert(!IChar(IntervalSet.empty[UChar]).nonEmpty)
+    assert(IChar(IntervalSet((UChar(0x41), UChar(0x42)))).nonEmpty)
   }
 
   test("IChar#complement") {
@@ -126,17 +118,17 @@ class ICharSuite extends munit.FunSuite {
   }
 
   test("IChar#union") {
-    assertEquals(IChar('a') union IChar('b'), IChar(IntervalSet((UChar('a'), UChar('c'))), false, false))
+    assertEquals(IChar('a') union IChar('b'), IChar(IntervalSet((UChar('a'), UChar('c')))))
   }
 
   test("IChar#partition") {
     assertEquals(
-      IChar(IntervalSet((UChar(0x41), UChar(0x42))), true, false)
-        .partition(IChar(IntervalSet((UChar(0x41), UChar(0x5b))), false, true)),
+      IChar(IntervalSet((UChar(0x41), UChar(0x42))))
+        .partition(IChar(IntervalSet((UChar(0x41), UChar(0x5b))))),
       Partition(
-        IChar(IntervalSet((UChar(0x41), UChar(0x42))), true, true),
-        IChar(IntervalSet.empty, true, false),
-        IChar(IntervalSet((UChar(0x42), UChar(0x5b))), false, true)
+        IChar(IntervalSet((UChar(0x41), UChar(0x42)))),
+        IChar(IntervalSet.empty[UChar]),
+        IChar(IntervalSet((UChar(0x42), UChar(0x5b))))
       )
     )
   }
@@ -157,8 +149,8 @@ class ICharSuite extends munit.FunSuite {
   }
 
   test("IChar#compare") {
-    val c1 = IChar(IntervalSet((UChar(0x41), UChar(0x42))), false, false)
-    val c2 = IChar(IntervalSet((UChar(0x42), UChar(0x43))), false, false)
+    val c1 = IChar(IntervalSet((UChar(0x41), UChar(0x42))))
+    val c2 = IChar(IntervalSet((UChar(0x42), UChar(0x43))))
     assertEquals(c1.compare(c1), 0)
     assertEquals(c1.compare(c2), -1)
     assertEquals(c2.compare(c1), 1)
@@ -166,12 +158,8 @@ class ICharSuite extends munit.FunSuite {
 
   test("IChar#toString") {
     assertEquals(
-      IChar(IntervalSet((UChar('a'), UChar('b')), (UChar('A'), UChar('Z' + 1))), true, false).toString,
-      "[A-Za]n"
-    )
-    assertEquals(
-      IChar(IntervalSet((UChar('a'), UChar('z' + 1)), (UChar('A'), UChar('B'))), false, true).toString,
-      "[Aa-z]w"
+      IChar(IntervalSet((UChar('a'), UChar('b')), (UChar('A'), UChar('Z' + 1)))).toString,
+      "[A-Za]"
     )
     assertEquals(
       IChar('\u0001').union(IChar('-')).union(IChar(UChar(0x10ffff))).toString,

--- a/modules/recheck/shared/src/test/scala/codes/quine/labo/recheck/regexp/PatternSuite.scala
+++ b/modules/recheck/shared/src/test/scala/codes/quine/labo/recheck/regexp/PatternSuite.scala
@@ -7,6 +7,7 @@ import codes.quine.labo.recheck.common.Context
 import codes.quine.labo.recheck.common.InvalidRegExpException
 import codes.quine.labo.recheck.data.IChar
 import codes.quine.labo.recheck.data.ICharSet
+import codes.quine.labo.recheck.data.ICharSet.CharKind
 import codes.quine.labo.recheck.data.UString
 import codes.quine.labo.recheck.regexp.Pattern._
 
@@ -321,8 +322,8 @@ class PatternSuite extends munit.FunSuite {
     val flagSet2 = FlagSet(false, false, false, true, false, false)
     val flagSet3 = FlagSet(false, true, false, false, false, false)
     val flagSet4 = FlagSet(false, true, false, false, true, false)
-    val word = IChar.Word.withWord
-    val lineTerminator = IChar.LineTerminator.withLineTerminator
+    val word = IChar.Word
+    val lineTerminator = IChar.LineTerminator
     val dot16 = IChar.Any16.diff(IChar.LineTerminator)
     val dot = IChar.Any.diff(IChar.LineTerminator)
     assertEquals(Pattern(Sequence(Seq.empty), flagSet0).alphabet, Success(ICharSet.any(false, false)))
@@ -333,15 +334,15 @@ class PatternSuite extends munit.FunSuite {
     )
     assertEquals(
       Pattern(WordBoundary(false), flagSet0).alphabet,
-      Success(ICharSet.any(false, false).add(word))
+      Success(ICharSet.any(false, false).add(word, CharKind.Word))
     )
     assertEquals(
       Pattern(LineBegin(), flagSet1).alphabet,
-      Success(ICharSet.any(false, false).add(lineTerminator))
+      Success(ICharSet.any(false, false).add(lineTerminator, CharKind.LineTerminator))
     )
     assertEquals(
       Pattern(Sequence(Seq(LineBegin(), WordBoundary(false))), flagSet1).alphabet,
-      Success(ICharSet.any(false, false).add(lineTerminator).add(word))
+      Success(ICharSet.any(false, false).add(lineTerminator, CharKind.LineTerminator).add(word, CharKind.Word))
     )
     assertEquals(Pattern(Capture(1, Dot()), flagSet2).alphabet, Success(ICharSet.any(false, false)))
     assertEquals(Pattern(NamedCapture(1, "foo", Dot()), flagSet2).alphabet, Success(ICharSet.any(false, false)))


### PR DESCRIPTION
They are moved to `ICharSet` because `IChar` is used in many places other than the `automaton` package.

These PR benefits are:

- simplified some implementations
- performance improvements (because `IChar` needs less memory space now?)
