### PR TITLE
Add `.yarnrc` to set `--ignore-platform` option

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,7 @@ jobs:
           node-version: '14'
           cache: 'yarn'
       - name: Install
-        run: yarn install --frozen-lockfile --ignore-platform
+        run: yarn install --frozen-lockfile
       - name: Lint
         run: |
           yarn workspace eslint-plugin-redos lint
@@ -109,7 +109,7 @@ jobs:
           node-version: '14'
           cache: 'yarn'
       - name: Install
-        run: yarn install --frozen-lockfile --ignore-platform
+        run: yarn install --frozen-lockfile
       - uses: actions/download-artifact@v2
         with:
           name: recheck.js
@@ -242,7 +242,7 @@ jobs:
             **/target
           key: ${{ runner.os }}-build-${{ github.sha }}
       - name: Install
-        run: yarn install --frozen-lockfile --ignore-platform
+        run: yarn install --frozen-lockfile
       - uses: actions/download-artifact@v2
         with:
           name: recheck.js

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+--ignore-platform true


### PR DESCRIPTION
To develop NPM package, we need to add `--ignore-platform` option to `yarn` command.
It is shameful and hard to maintain workflows. Thus, we want to use `.yarnrc` to set the option.

## Changes

- Add `.yarnrc` to set `--ignore-platform` option