### PR TITLE
Fill in `homepage` and `repository` of `package.json`

### DIFF
--- a/packages/eslint-plugin-redos/package.json
+++ b/packages/eslint-plugin-redos/package.json
@@ -3,6 +3,8 @@
   "description": "ESLint plugin for catching ReDoS vulnerability.",
   "license": "MIT",
   "author": "TSUYUSATO Kitsune <make.just.on@gmail.com>",
+  "homepage": "https://makenowjust-labo.github.io/recheck/",
+  "repository": "https://github.com/MakeNowJust-Labo/recheck.git",
   "version": "4.1.1",
   "main": "lib/index.js",
   "files": [


### PR DESCRIPTION
`homepage` and `repository` fields are missing in `package.json` of `eslint-plugin-redos`.

## Changes

- Fill in `homepage` and `repository` of `package.json`