### PR TITLE
Don't minify worker.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,5 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+.hugo_build.lock

--- a/site/layouts/partials/header.html
+++ b/site/layouts/partials/header.html
@@ -162,7 +162,8 @@
   </div>
 </header>
 
-{{ $workerJS := resources.Get "js/worker.js" | js.Build "worker.js" | minify | fingerprint }}
+{{/* FIXME: worker.js is not minified due to Hugo (ESBuild) bug. If it is fixed, we should add `minify` filter again. */}}
+{{ $workerJS := resources.Get "js/worker.js" | js.Build "worker.js" | fingerprint }}
 {{ $opts := dict "targetPath" "main.js" "params" (dict "workerJS" $workerJS.Permalink) }}
 {{ $mainJS := resources.Get "js/main.js" | js.Build $opts | minify | fingerprint }}
 <script src="{{ $mainJS.Permalink }}"></script>


### PR DESCRIPTION
Hugo 0.89.4 uses the old esbuild, and it has a bug related to minification with bare unicode escape identifier.
For now, it fixes to not minify worker.js.

## Changes

- Remove `minify` filter for `worker.js`.