### PR TITLE
Set up Node.js on scala-test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,6 +86,10 @@ jobs:
       - uses: olafurpg/setup-scala@v13
         with:
           java-version: adopt@1.16
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '17'
+          cache: 'yarn'
       - name: Cache SBT
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
## Changes

- Set up Node.js on `scala-test` job because `node` is used in Scala.js testing.