### PR TITLE
Fix semaphore usage in test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Changes:
 - Improve repetition count estimation ([#227](https://github.com/MakeNowJust-Labo/recheck/pull/227))
 - Use JavaScript style representation for `AttackPattern#toString` ([#229](https://github.com/MakeNowJust-Labo/recheck/pull/229))
 
+Fixes:
+
+- Fix semaphore usage in test ([#230](https://github.com/MakeNowJust-Labo/recheck/pull/230))
+
 # 4.1.1 (2021-12-04)
 
 Fixes:

--- a/modules/recheck-cli/src/test/scala/codes/quine/labo/recheck/cli/AgentCommandSuite.scala
+++ b/modules/recheck-cli/src/test/scala/codes/quine/labo/recheck/cli/AgentCommandSuite.scala
@@ -24,7 +24,7 @@ class AgentCommandSuite extends munit.FunSuite {
       Right(s"""{"jsonrpc":"${RPC.JsonRPCVersion}","id":5,$complex}""")
     )
     val out = Seq.newBuilder[String]
-    val sem = new Semaphore(1)
+    val sem = new Semaphore(0)
     val io = new RPC.IO {
       def read(): Iterator[String] =
         in.iterator.flatMap {


### PR DESCRIPTION
## Changes

- Fix semaphore usage in `AgentCommand` test

I believe this fixes the flaky test.