### PR TITLE
Fix sbt file issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Changes:
 Fixes:
 
 - Fix semaphore usage in test ([#230](https://github.com/MakeNowJust-Labo/recheck/pull/230))
+- Fix `sbt` file issues ([#231](https://github.com/MakeNowJust-Labo/recheck/pull/231))
 
 # 4.1.1 (2021-12-04)
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 Global / onChangedBuildSource := ReloadOnSourceChanges
+Global / excludeLintKeys += nativeImageVersion
 
 ThisBuild / organization := "codes.quine.labo"
 ThisBuild / homepage := Some(url("https://github.com/MakeNowJust-Labo/recheck"))
@@ -41,7 +42,8 @@ lazy val root = project
         else version.value
       }
     ),
-    mdocOut := baseDirectory.value / "site" / "content"
+    mdocOut := baseDirectory.value / "site" / "content",
+    addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1")
   )
   .enablePlugins(MdocPlugin)
   .aggregate(coreJVM, coreJS, commonJVM, commonJS, unicodeJVM, unicodeJS, parseJVM, parseJS, codecJVM, codecJS, js, cli)


### PR DESCRIPTION
## Changes

- To disable `lintUnused` false-positive warning, set `excludeLintKeys`.
- Add `better-monadic-for` plugin to `root` for `mdoc` task
