### PR TITLE
Use require directly instead of module.require

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Fixes:
 
 - Don't bundle recheck in eslint-plugin-redos ([#260](https://github.com/MakeNowJust-Labo/recheck/pull/260))
+- Use `require` directly instead of `module.require` ([#261](https://github.com/MakeNowJust-Labo/recheck/pull/261))
 
 # 4.2.0 (2022-01-08)
 

--- a/packages/recheck/src/lib/exe.ts
+++ b/packages/recheck/src/lib/exe.ts
@@ -1,7 +1,7 @@
 import * as env from "./env";
 
 /** Exposes this to mock `require.resolve` on testing. */
-export const __mock__require = module.require;
+export const __mock__require = require;
 
 /** Returns `recheck.jar` file path, or `null` if it is not found. */
 export const jar: () => string | null = () => {


### PR DESCRIPTION
Currently, `java` and `native` backends do not work correctly because `module.require` has no `resolve` method. So, they are errored and fall back unfortunately into `pure`.

## Changes

- Use require directly instead of module.require