### PR TITLE
Fix `handleLine` in `Agent` for large data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# dev
+
+Fixes:
+
+- Fix `handleLine` in `Agent` for large data ([#266](https://github.com/MakeNowJust-Labo/recheck/pull/266))
+
 # 4.2.1 (2022-01-08)
 
 Fixes:

--- a/packages/recheck/package.json
+++ b/packages/recheck/package.json
@@ -18,8 +18,8 @@
   "scripts": {
     "build": "sucrase-node ./scripts/build.ts",
     "clean": "rimraf lib",
-    "format": "prettier -w '*.{js,json,md}' 'src/**/*.ts' index.d.ts",
-    "lint": "prettier --list-different '*.{js,json,md}' 'src/**/*.ts' index.d.ts",
+    "format": "prettier -w '*.{js,json,md}' 'src/**/*.{js,ts}' index.d.ts",
+    "lint": "prettier --list-different '*.{js,json,md}' 'src/**/*.{js,ts}' index.d.ts",
     "test": "jest",
     "typecheck": "tsc --noEmit -p ."
   },

--- a/packages/recheck/src/lib/__test__/test-agent.js
+++ b/packages/recheck/src/lib/__test__/test-agent.js
@@ -25,7 +25,15 @@ process.stdin.on('data', data => {
       case 'check':
         console.log(JSON.stringify({ jsonrpc: "2.0+push", id: json.id, message: 'message' }));
         checks[json.id] = setTimeout(() => {
-          console.log(JSON.stringify({ jsonrpc: "2.0+push", id: json.id, result: { status: 'safe' } }));
+          switch (json.params.source) {
+            case 'test-large':
+              const string = 'a'.repeat(300_000);
+              console.log(JSON.stringify({ jsonrpc: "2.0+push", id: json.id, result: { status: 'vulnerable', attack: { string } } }));
+              break;
+            default:
+              console.log(JSON.stringify({ jsonrpc: "2.0+push", id: json.id, result: { status: 'safe' } }));
+              break;
+          }
           delete checks[json.id];
         }, 100);
         break;

--- a/packages/recheck/src/lib/__test__/test-agent.js
+++ b/packages/recheck/src/lib/__test__/test-agent.js
@@ -1,44 +1,80 @@
 let count = 0;
 let checks = {};
 
-process.stdin.on('data', data => {
-  const lines = data.toString('utf-8').split('\n').filter(Boolean);
+process.stdin.on("data", (data) => {
+  const lines = data.toString("utf-8").split("\n").filter(Boolean);
   for (line of lines) {
     const json = JSON.parse(line);
     switch (json.method) {
-      case 'ping':
+      case "ping":
         // Tests to ignore unexpected inputs.
         console.log();
-        console.log(JSON.stringify({ jsonrpc: "2.0+push", id: json.id - 1, result: {} }));
+        console.log(
+          JSON.stringify({ jsonrpc: "2.0+push", id: json.id - 1, result: {} })
+        );
 
-        console.log(JSON.stringify({ jsonrpc: "2.0+push", id: json.id, result: {} }));
+        console.log(
+          JSON.stringify({ jsonrpc: "2.0+push", id: json.id, result: {} })
+        );
         break;
-      case 'test-request':
-        console.log(JSON.stringify({ jsonrpc: "2.0+push", id: json.id, message: 'message' }));
-        console.log(JSON.stringify({ jsonrpc: "2.0+push", id: json.id, result: count }));
+      case "test-request":
+        console.log(
+          JSON.stringify({
+            jsonrpc: "2.0+push",
+            id: json.id,
+            message: "message",
+          })
+        );
+        console.log(
+          JSON.stringify({ jsonrpc: "2.0+push", id: json.id, result: count })
+        );
         break;
-      case 'test-notify':
+      case "test-notify":
         count += 1;
         break;
 
       // A fake `checker` implementation.
-      case 'check':
-        console.log(JSON.stringify({ jsonrpc: "2.0+push", id: json.id, message: 'message' }));
+      case "check":
+        console.log(
+          JSON.stringify({
+            jsonrpc: "2.0+push",
+            id: json.id,
+            message: "message",
+          })
+        );
         checks[json.id] = setTimeout(() => {
           switch (json.params.source) {
-            case 'test-large':
-              const string = 'a'.repeat(300_000);
-              console.log(JSON.stringify({ jsonrpc: "2.0+push", id: json.id, result: { status: 'vulnerable', attack: { string } } }));
+            case "test-large":
+              const string = "a".repeat(300_000);
+              console.log(
+                JSON.stringify({
+                  jsonrpc: "2.0+push",
+                  id: json.id,
+                  result: { status: "vulnerable", attack: { string } },
+                })
+              );
               break;
             default:
-              console.log(JSON.stringify({ jsonrpc: "2.0+push", id: json.id, result: { status: 'safe' } }));
+              console.log(
+                JSON.stringify({
+                  jsonrpc: "2.0+push",
+                  id: json.id,
+                  result: { status: "safe" },
+                })
+              );
               break;
           }
           delete checks[json.id];
         }, 100);
         break;
-      case 'cancel':
-        console.log(JSON.stringify({ jsonrpc: "2.0+push", id: json.params.id, result: { status: 'unknown' } }));
+      case "cancel":
+        console.log(
+          JSON.stringify({
+            jsonrpc: "2.0+push",
+            id: json.params.id,
+            result: { status: "unknown" },
+          })
+        );
         clearTimeout(checks[json.params.id]);
         delete checks[json.params.id];
         break;

--- a/packages/recheck/src/lib/agent.test.ts
+++ b/packages/recheck/src/lib/agent.test.ts
@@ -56,7 +56,7 @@ test("check: with large output", async () => {
   const agent = await start("node", [testAgent]);
   await expect(checkAgent(agent, "test-large", "")).resolves.toEqual({
     status: "vulnerable",
-    attack: { string: 'a'.repeat(300_000) }
+    attack: { string: "a".repeat(300_000) },
   });
 });
 

--- a/packages/recheck/src/lib/agent.test.ts
+++ b/packages/recheck/src/lib/agent.test.ts
@@ -15,15 +15,15 @@ afterEach(() => {
 });
 
 test("start", async () => {
-  await expect(startAgent("node", [testAgent])).resolves.toBeInstanceOf(Agent);
+  await expect(start("node", [testAgent])).resolves.toBeInstanceOf(Agent);
 });
 
 test("start: invalid", async () => {
-  await expect(startAgent("node", [invalid])).rejects.toThrowError();
+  await expect(start("node", [invalid])).rejects.toThrowError();
 });
 
 test("Agent#request", async () => {
-  const agent = await startAgent("node", [testAgent]);
+  const agent = await start("node", [testAgent]);
   const { id, promise } = agent.request("test-request", {});
   expect(id).toBe(1);
   await expect(promise).resolves.toBe(0);
@@ -32,7 +32,7 @@ test("Agent#request", async () => {
 test("Agent#request: with message", async () => {
   expect.assertions(3);
 
-  const agent = await startAgent("node", [testAgent]);
+  const agent = await start("node", [testAgent]);
   const subscribe = (message: string) => expect(message).toBe("message");
   const { id, promise } = agent.request("test-request", {}, subscribe);
   expect(id).toBe(1);
@@ -40,43 +40,51 @@ test("Agent#request: with message", async () => {
 });
 
 test("Agent#notify", async () => {
-  const agent = await startAgent("node", [testAgent]);
+  const agent = await start("node", [testAgent]);
   await agent.notify("test-notify", {});
   await expect(agent.request("test-request", {}).promise).resolves.toBe(1);
 });
 
 test("check", async () => {
-  const agent = await startAgent("node", [testAgent]);
-  await expect(checkAgent(agent, "foo", "")).resolves.toEqual({
+  const agent = await start("node", [testAgent]);
+  await expect(checkAgent(agent, "test", "")).resolves.toEqual({
     status: "safe",
+  });
+});
+
+test("check: with large output", async () => {
+  const agent = await start("node", [testAgent]);
+  await expect(checkAgent(agent, "test-large", "")).resolves.toEqual({
+    status: "vulnerable",
+    attack: { string: 'a'.repeat(300_000) }
   });
 });
 
 test("check: with logger", async () => {
   expect.assertions(2);
 
-  const agent = await startAgent("node", [testAgent]);
+  const agent = await start("node", [testAgent]);
   const logger = (message: string) => expect(message).toBe("message");
-  await expect(checkAgent(agent, "foo", "", { logger })).resolves.toEqual({
+  await expect(checkAgent(agent, "test", "", { logger })).resolves.toEqual({
     status: "safe",
   });
 });
 
 test("check: with abort (1)", async () => {
-  const agent = await startAgent("node", [testAgent]);
+  const agent = await start("node", [testAgent]);
   const controller = new AbortController();
   const signal = controller.signal;
   controller.abort();
-  await expect(checkAgent(agent, "foo", "", { signal })).resolves.toEqual({
+  await expect(checkAgent(agent, "test", "", { signal })).resolves.toEqual({
     status: "unknown",
   });
 });
 
 test("check: with abort (2)", async () => {
-  const agent = await startAgent("node", [testAgent]);
+  const agent = await start("node", [testAgent]);
   const controller = new AbortController();
   const signal = controller.signal;
-  const run = checkAgent(agent, "foo", "", { signal });
+  const run = checkAgent(agent, "test", "", { signal });
   setTimeout(() => controller.abort(), 10);
   await expect(run).resolves.toEqual({ status: "unknown" });
 });

--- a/packages/recheck/src/lib/agent.ts
+++ b/packages/recheck/src/lib/agent.ts
@@ -104,8 +104,8 @@ export class Agent {
       const firstLine = lines.shift() ?? "";
 
       if (hasNewline) {
-        lines.unshift(remainingLastLine + firstLine)
-        remainingLastLine = '';
+        lines.unshift(remainingLastLine + firstLine);
+        remainingLastLine = "";
       }
 
       for (const line of lines) {

--- a/packages/recheck/src/lib/agent.ts
+++ b/packages/recheck/src/lib/agent.ts
@@ -94,20 +94,25 @@ export class Agent {
       }
     };
 
-    this.child.stdout!.on("data", (data) => {
+    this.child.stdout!.on("data", (data: Buffer) => {
       const text = data.toString("utf-8");
       const lines = text.split("\n");
+      const hasNewline = lines.length > 1;
 
-      /* c8 ignore next 2 */
+      /* c8 ignore next 1 */
       const lastLine = lines.pop() ?? "";
       const firstLine = lines.shift() ?? "";
 
-      handleLine(remainingLastLine + firstLine);
+      if (hasNewline) {
+        lines.unshift(remainingLastLine + firstLine)
+        remainingLastLine = '';
+      }
+
       for (const line of lines) {
         handleLine(line);
       }
 
-      remainingLastLine = lastLine;
+      remainingLastLine += lastLine;
     });
   }
 


### PR DESCRIPTION
When the `agent` process sends data across two or more `'data'` events, JSON parsing is failed.
This commit fixes `handleLine` in `Agent` to handle such data correctly.

## Changes

- Fix `handleLine` in `Agent` for large data