### PR TITLE
Add missing field `AttackPattern#pattern` in TypeScript definition

### DIFF
--- a/packages/recheck/index.d.ts
+++ b/packages/recheck/index.d.ts
@@ -435,4 +435,5 @@ export type AttackPattern = {
   suffix: string;
   base: number;
   string: string;
+  pattern: string;
 };


### PR DESCRIPTION
## Changes

- Add missing field `AttackPattern#pattern` in TypeScript definition